### PR TITLE
Fixed git checkout of proper u-boot version

### DIFF
--- a/rpi3-convert-stage-5.sh
+++ b/rpi3-convert-stage-5.sh
@@ -50,10 +50,11 @@ build_uboot_files() {
 
   if [ ! -d $uboot_repo_vc_dir ]; then
     git clone https://github.com/mendersoftware/uboot-mender.git -b $branch
-    git checkout $commit
   fi
 
   cd $uboot_dir
+
+  git checkout $commit
 
   make --quiet distclean
   make --quiet rpi_3_32b_defconfig && make --quiet


### PR DESCRIPTION
We do not checkout given u-boot version, because we are not in u-boot directory. Now it is fixed

Signed-off-by: Dominik Adamski <adamski.dominik@gmail.com>