### PR TITLE
Use fix GRUB version for kernels newer than 4.12

### DIFF
--- a/bbb-convert-stage-5.sh
+++ b/bbb-convert-stage-5.sh
@@ -123,6 +123,8 @@ build_grub_efi() {
     # To avoid error message: "plain image kernel not supported - rebuild
     # with CONFIG_(U)EFI_STUB enabled" - use a specific commit.
     git checkout 9b37229f0 >> "$build_log" 2>&1
+  else
+    git checkout 72e80c025 >> "$build_log" 2>&1
   fi
 
   mkdir -p $grub_arm_dir


### PR DESCRIPTION
Previously we have always builded the newest version of the GRUB. It was unstable because we cannot track all changes in GRUB repository. Now we build only checked version of GRUB/

Signed-off-by: Dominik Adamski <adamski.dominik@gmail.com>