### PR TITLE
Fixed vfat storage offset for RPi.

### DIFF
--- a/mender-convert
+++ b/mender-convert
@@ -305,6 +305,10 @@ do_raw_disk_image_create_partitions() {
        \n\t\troot filesystem size: $((${prootfs_size} * $sector_size)) bytes\
        \n\t\tdata partition size: $(($pdata_size * $sector_size)) bytes"
 
+  local vfat_storage_offset=
+  [[ $raw_disk_counts -eq 1 ]] && { vfat_storage_offset=$vfat_storage_offset_regular; } \
+                              || { vfat_storage_offset=$vfat_storage_offset_extended; }
+
   create_test_config_file $device_type $partition_alignment $vfat_storage_offset \
                           $pboot_size $prootfs_size $pdata_size $mender_disk_image_size \
                           $sector_size

--- a/mender-convert-functions.sh
+++ b/mender-convert-functions.sh
@@ -2,8 +2,11 @@
 
 # Partition alignment value in bytes (8MB).
 partition_alignment=8388608
-# Boot partition storage offset in bytes (8MB).
-vfat_storage_offset=8388608
+# Boot partition storage offset in bytes (equal to alignment).
+vfat_storage_offset_regular=$partition_alignment
+#erase_block=12582912
+# Boot partition storage offset in bytes (alignment * 2).
+vfat_storage_offset_extended=$(($partition_alignment*2 ))
 # Number of required heads in a final image.
 heads=255
 # Number of required sectors in a final image.
@@ -294,10 +297,13 @@ analyse_raw_disk_image() {
     rootfssize=$bootsize
     # Default size of the boot partition: 16MiB.
     bootsize=$(( ($partition_alignment * 2) / $sectorsize ))
+    # Boot partition storage offset is defined from the top down.
+    bootstart=$(( $vfat_storage_offset_regular / $sectorsize ))
+  elif [[ $count -eq 2 ]]; then
+    # Boot partition storage offset is defined from the top down.
+    bootstart=$(( $vfat_storage_offset_extended / $sectorsize ))
   fi
 
-  # Boot partition storage offset is defined from the top down.
-  bootstart=$(( $vfat_storage_offset / $sectorsize ))
 
   align_partition_size bootsize $sectorsize
   align_partition_size rootfssize  $sectorsize


### PR DESCRIPTION
The overlap was between boot partition and storage location of U-boot environment.

Signed-off-by: Dominik Adamski <adamski.dominik@gmail.com>