### PR TITLE
fix image paths printed at end of conversion

### DIFF
--- a/mender-convert
+++ b/mender-convert
@@ -817,10 +817,10 @@ case "$1" in
     [[ $rc -ne 0 ]] && { log "Check $build_log for details."; exit 1; }
     log "Conversion complete!"
     log "The Mender disk image you can provision your device storage with is at:\
-         \n\t${mender_disk_image}."
-    log "The Mender root file system partition is at:\n\t${mender_rootfs_image}."
+         \n\t${mender_disk_image}"
+    log "The Mender root file system partition is at:\n\t${mender_rootfs_image}"
     log "The Mender Artifact you can upload to your Mender server to deploy to your devices is at:\
-         \n\t${mender_artifact}."
+         \n\t${mender_artifact}"
     ;;
   *)
     show_help


### PR DESCRIPTION
Example with the error:

```
The Mender disk image you can provision your device storage with is at:         
	/mender-convert/output/2018-10-09-raspbian-stretch.sdimg.
The Mender root file system partition is at:
	/mender-convert/output/2018-10-09-raspbian-stretch.ext4.
The Mender Artifact you can upload to your Mender server to deploy to your devices is at:         
	/mender-convert/output/2018-10-09-raspbian-stretch.mender.
root@b8bd40486303:/mender-convert# ls /mender-convert/output/2018-10-09-raspbian-stretch.ext4.
ls: cannot access '/mender-convert/output/2018-10-09-raspbian-stretch.ext4.': No such file or directory
```