### PR TITLE
Avoid duplicating cmdline.txt contents

### DIFF
--- a/rpi3-convert-stage-5.sh
+++ b/rpi3-convert-stage-5.sh
@@ -103,7 +103,7 @@ install_files() {
   # case it is missing, add it back to cmdline.txt
   if ! grep -q "init=/usr/lib/raspi-config/init_resize.sh" ${output_dir}/cmdline.txt; then
     cmdline=$(cat ${output_dir}/cmdline.txt)
-    sh -c -e "echo '${cmdline} init=/usr/lib/raspi-config/init_resize.sh' >> ${output_dir}/cmdline.txt";
+    sh -c -e "echo '${cmdline} init=/usr/lib/raspi-config/init_resize.sh' > ${output_dir}/cmdline.txt";
   fi
 
   # Update Linux kernel command arguments with our custom configuration


### PR DESCRIPTION
If `cmdline.txt` does not contain `init_resize.sh` it will be added back. Current code however ends up creating duplicated content. Updated `cmdline.txt` contains both the original line and the original line with `init_resize.sh` added. 

```
$ cat cmdline.txt
wc_otg.lpm_enable=0 console=serial0,115200 root=${mender_kernel_root} rootfstype=ext4 elevator=deadline fsck.repair=yes rootwait quiet
wc_otg.lpm_enable=0 console=serial0,115200 root=${mender_kernel_root} rootfstype=ext4 elevator=deadline fsck.repair=yes rootwait quiet init=/usr/lib/raspi-config/init_resize.sh
```

This PR fixes the problem.
