### PR TITLE
Update Mender client version to 1.7.0 in docker-build script

### DIFF
--- a/docker-build
+++ b/docker-build
@@ -4,6 +4,6 @@ set -e
 
 IMAGE_NAME=mender-convert
 
-MENDER_CLIENT_VERSION="1.6.0"
+MENDER_CLIENT_VERSION="1.7.0"
 
 docker build . -t ${IMAGE_NAME} --build-arg mender_client_version=${MENDER_CLIENT_VERSION}


### PR DESCRIPTION
Use Mender 1.7.0 version as the default version.

Signed-off-by: Dominik Adamski <adamski.dominik@gmail.com>