### PR TITLE
Provide systemd service for Raspberry Pi boards to resize data partition

### DIFF
--- a/files/init_resize.sh
+++ b/files/init_resize.sh
@@ -75,7 +75,7 @@ main () {
     reboot_pi
   fi
 
-if ! parted -m $ROOT_DEV u s resizepart $ROOT_PART_NUM $TARGET_END; then
+  if ! parted -m $ROOT_DEV u s resizepart $ROOT_PART_NUM $TARGET_END; then
     FAIL_REASON="Data partition resize failed"
     return 1
   fi

--- a/files/resizefs.service
+++ b/files/resizefs.service
@@ -1,0 +1,13 @@
+[Unit]
+Description=Expand data partition file system
+After=mender.service
+
+[Service]
+Type=simple
+User=root
+Group=root
+ExecStart=/bin/sh -c 'sleep 1 ; /usr/sbin/resizefs.sh start'
+RemainAfterExit=true
+
+[Install]
+WantedBy=multi-user.target

--- a/files/resizefs.sh
+++ b/files/resizefs.sh
@@ -1,0 +1,42 @@
+#!/bin/sh
+### BEGIN INIT INFO
+# Provides: resizefs
+# Required-Start:
+# Required-Stop:
+# Default-Start: 3
+# Default-Stop:
+# Short-Description: Resize the data filesystem to fill partition
+# Description:
+### END INIT INFO
+
+. /lib/lsb/init-functions
+
+case "$1" in
+  start)
+    log_daemon_msg "Starting resizefs service (once)"
+    DISK=$(lsblk -f | sed -n '2{p;q}')
+    DISK_DEV="/dev/$DISK"
+    DISK_SIZE=$(blockdev --getsize $DISK_DEV)
+    DATA_PART_DEV=$(findmnt /data -o source -n)
+    DATA_PART=$(basename $DATA_PART_DEV)
+    DATA_PART_START=$(parted -m $DISK_DEV unit s print | tr -d 's' | tail -n 1 | cut -d ":" -f 2)
+    DATA_PART_SIZE=$(blockdev --getsize $DATA_PART_DEV)
+    FREE_SPACE=`expr $DISK_SIZE - $DATA_PART_START - $DATA_PART_SIZE`
+
+    if [ $FREE_SPACE -eq 0 ]; then
+      log_daemon_msg "Data partition already resized, aborting"
+    else
+      resize2fs $DATA_PART_DEV
+      FSSIZEMEG=`expr $FREE_SPACE + $DATA_PART_SIZE`
+      FSSIZEMEG=`expr $FSSIZEMEG / 2 / 1024`"M"
+      log_daemon_msg "Resizing $DATA_PART finished, new size is $FSSIZEMEG"
+    fi
+
+    systemctl --no-reload disable resizefs.service
+    log_end_msg $?
+    ;;
+  *)
+    echo "Usage: $0 start" >&2
+    exit 3
+    ;;
+esac


### PR DESCRIPTION
As the partition table has been modified 'resize2fs_once' service
no longer fulfils its purpose.
That service has been replaced with 'resizefs' systemd service
which extends data partition's size and resizes filesystem too
to fill the whole free unallocated space.

Issues: MEN-2254

Changelog: Title

Signed-off-by: Adam Podogrocki <a.podogrocki@gmail.com>