### PR TITLE
Fix for Raspberry Pi Zero W not booting

### DIFF
--- a/rpi-convert-stage-5.sh
+++ b/rpi-convert-stage-5.sh
@@ -43,7 +43,7 @@ build_uboot_files() {
   local uboot_repo_vc_dir=$uboot_dir/.git
   local defconfig="rpi_3_32b_defconfig"
 
-  if [ "$2" == "raspberrypi0" ]; then
+  if [ "$2" == "raspberrypi0w" ]; then
     defconfig="rpi_0_w_defconfig"
   fi
 


### PR DESCRIPTION
Fix for using the uboot for Raspberry Pi Zero W and not Raspberry Pi 3 when the parameter "raspberrypi0w" is used

Changelog: Fix for Raspberry Pi Zero W not booting
 
Signed-off-by: Adrian Cuzman adrian.cuzman@gmail.com