### PR TITLE
convert-stage-4: interval settings must be 'int' and not strings

### DIFF
--- a/convert-stage-4.sh
+++ b/convert-stage-4.sh
@@ -101,14 +101,14 @@ create_client_files() {
 
   cat <<- EOF > $mender_dir/mender.conf
 	{
-	    "InventoryPollIntervalSeconds": "$inventPollInterval",
-	    "RetryPollIntervalSeconds": "$retryPollInterval",
+	    "InventoryPollIntervalSeconds": $inventPollInterval,
+	    "RetryPollIntervalSeconds": $retryPollInterval,
 	    "RootfsPartA": "$rootfsparta",
 	    "RootfsPartB": "$rootfspartb",
 	    "ServerCertificate": "/etc/mender/server.crt",
 	    "ServerURL": "$mender_server_url",
 	    "TenantToken": "$mender_tenant_token",
-	    "UpdatePollIntervalSeconds": "$updatePollInterval"
+	    "UpdatePollIntervalSeconds": $updatePollInterval
 	}
 	EOF
 


### PR DESCRIPTION
Fixes: 151eb4d784 ("MEN-2248: Set production/demo intervals conditionally")

Changelog: None

Signed-off-by: Mirza Krak <mirza.krak@northern.tech>