### PR TITLE
Give container access to host's kernel modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,6 @@ After it finishes, you can find your images in the `output` directory on your ho
 
 
 ### Known issues
-* BeagleBone images might not convert properly using this docker envirnoment due to permission issues: `mount: /mender-convert/output/embedded/rootfs: WARNING: device write-protected, mounted read-only.`
 * Raspberrypi0w cpu isn't armv7+ architecture (it's armv6) and because of this mender client + u-boot fw_set/getenv tools are crashing when compiled with armv7 toolchain added in docker image. Pls use this forked [repo](https://github.com/nandra/mender-conversion-tools/commits/rpi0w-toolchain) to have it properly build with other armv6 toolchain.
 * If building U-boot fails with:
 ```

--- a/docker-mender-convert
+++ b/docker-mender-convert
@@ -10,4 +10,7 @@ mkdir -p output
 docker run \
        --mount type=bind,source="$MENDER_CONVERT_DIR,target=/mender-convert" \
        --privileged=true \
+       --cap-add=SYS_MODULE \
+       -v /dev:/dev \
+       -v /lib/modules:/lib/modules:ro \
        $IMAGE_NAME "$@"


### PR DESCRIPTION
To get rid of such errors/warnings as:
- mount: could not find any device /dev/loop#
- mount: ... WARNING: device write-protected, mounted read-only
access to host's kernel modules must be added.

Changelog: Title

Issues: MEN-2255

Signed-off-by: Adam Podogrocki <a.podogrocki@gmail.com>