### PR TITLE
Use a toolchain tuned for ARMv6 architecture to maintain support for …

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,3 +10,4 @@ script:
     - mendertesting/check_commits.sh
     # Check licenses
     - mendertesting/check_license.sh
+    - ./docker-build

--- a/Dockerfile
+++ b/Dockerfile
@@ -29,50 +29,57 @@ RUN apt-get update && apt-get install -y \
 # to download mender-artifact
     wget \
 # to download mender-convert and U-Boot sources
-    git \
-# To compile Mender client, U-boot or GRUB
-    gcc-arm-linux-gnueabihf
+    git
 
 # Disable sanity checks made by mtools. These checks reject copy/paste operations on converted disk images.
 RUN echo "mtools_skip_check=1" >> $HOME/.mtoolsrc
 
+# To provide support for Raspberry Pi Zero W a toolchain tuned for ARMv6 architecture must be used.
+# https://tracker.mender.io/browse/MEN-2399
+# Assumes $(pwd) is /
+RUN wget -nc -q https://toolchains.bootlin.com/downloads/releases/toolchains/armv6-eabihf/tarballs/armv6-eabihf--glibc--stable-2018.11-1.tar.bz2 \
+    && tar -xjf armv6-eabihf--glibc--stable-2018.11-1.tar.bz2 \
+    && rm armv6-eabihf--glibc--stable-2018.11-1.tar.bz2 \
+    && echo export PATH=$PATH:/armv6-eabihf--glibc--stable-2018.11-1/bin >> /root/.bashrc
+
 RUN wget -q -O /usr/bin/mender-artifact https://d1b0l86ne08fsf.cloudfront.net/mender-artifact/$MENDER_ARTIFACT_VERSION/mender-artifact \
     && chmod +x /usr/bin/mender-artifact
-
-# Build liblzma from source
-RUN wget -q https://tukaani.org/xz/xz-5.2.4.tar.gz \
-    && tar -C /root -xzf xz-5.2.4.tar.gz \
-    && cd /root/xz-5.2.4 \
-    && ./configure --host=arm-linux-gnueabihf --prefix=/root/xz-5.2.4/install \
-    && make \
-    && make install
-
-ENV LIBLZMA_INSTALL_PATH "/root/xz-5.2.4/install"
 
 # Golang environment, for cross-compiling the Mender client
 RUN wget https://dl.google.com/go/go$GOLANG_VERSION.linux-amd64.tar.gz \
     && tar -C /usr/local -xzf go$GOLANG_VERSION.linux-amd64.tar.gz \
     && echo export PATH=$PATH:/usr/local/go/bin >> /root/.bashrc
 
-ARG mender_client_version
-
-ENV MENDER_CLIENT_VERSION=$mender_client_version
-
-# NOTE: we are assuming generic ARM board here, needs to be extended later
-
-ENV PATH "$PATH:/usr/local/go/bin"
+ENV PATH "$PATH:/usr/local/go/bin:/armv6-eabihf--glibc--stable-2018.11-1/bin"
 ENV GOPATH "/root/go"
+
+# Download Mender client
+ARG mender_client_version
+ENV MENDER_CLIENT_VERSION=$mender_client_version
 
 RUN go get -d github.com/mendersoftware/mender
 WORKDIR $GOPATH/src/github.com/mendersoftware/mender
 RUN git checkout $MENDER_CLIENT_VERSION
 
+ENV CC "arm-buildroot-linux-gnueabihf-gcc"
+
+# Build liblzma from source
+RUN wget -q https://tukaani.org/xz/xz-5.2.4.tar.gz \
+    && tar -C /root -xzf xz-5.2.4.tar.gz \
+    && cd /root/xz-5.2.4 \
+    && ./configure --host=arm-buildroot-linux-gnueabihf --prefix=/root/xz-5.2.4/install \
+    && make \
+    && make install
+
+ENV LIBLZMA_INSTALL_PATH "/root/xz-5.2.4/install"
+
+# NOTE: we are assuming generic ARM board here, needs to be extended later
 RUN env CGO_ENABLED=1 \
     CGO_CFLAGS="-I${LIBLZMA_INSTALL_PATH}/include" \
     CGO_LDFLAGS="-L${LIBLZMA_INSTALL_PATH}/lib" \
-    CC=arm-linux-gnueabihf-gcc \
+    CC=$CC \
     GOOS=linux \
-    GOARCH=arm make build
+    GOARM=6 GOARCH=arm make build
 
 WORKDIR /
 

--- a/README.md
+++ b/README.md
@@ -68,15 +68,21 @@ ARTIFACT_NAME="2018-11-13-raspbian-stretch"
 MENDER_DISK_IMAGE="2018-11-13-raspbian-stretch.sdimg"
 TENANT_TOKEN="<INSERT-TOKEN-FROM Hosted Mender>"
 
-./docker-mender-convert from-raw-disk-image                 \
-            --raw-disk-image $RAW_DISK_IMAGE                \
-            --mender-disk-image $MENDER_DISK_IMAGE          \
-            --device-type $DEVICE_TYPE                      \
-            --artifact-name $ARTIFACT_NAME                  \
-            --bootloader-toolchain arm-linux-gnueabihf      \
-            --server-url "https://hosted.mender.io"         \
+./docker-mender-convert from-raw-disk-image                      \
+            --raw-disk-image $RAW_DISK_IMAGE                     \
+            --mender-disk-image $MENDER_DISK_IMAGE               \
+            --device-type $DEVICE_TYPE                           \
+            --artifact-name $ARTIFACT_NAME                       \
+            --bootloader-toolchain arm-buildroot-linux-gnueabihf \
+            --server-url "https://hosted.mender.io"              \
             --tenant-token $TENANT_TOKEN
 ```
+
+By default conversion in containter uses GCC 7.3.0 bootlin toolchain tuned for
+ARMv6 architecture (especially for ARM1176(F)-S single-core processor).
+The aim of that is to provide a support for the Raspberry Pi Zero W development board.
+
+ARMv7 is backward compatible with ARMv6, so binaries compiled for ARMv6 should also work on ARMv7.
 
 Note that the default Mender client is the latest stable and cross-compiled for generic ARM boards,
 which should work well in most cases. If you would like to use a different Mender client,
@@ -89,7 +95,10 @@ After it finishes, you can find your images in the `output` directory on your ho
 
 
 ### Known issues
-* Raspberrypi0w cpu isn't armv7+ architecture (it's armv6) and because of this mender client + u-boot fw_set/getenv tools are crashing when compiled with armv7 toolchain added in docker image. Pls use this forked [repo](https://github.com/nandra/mender-conversion-tools/commits/rpi0w-toolchain) to have it properly build with other armv6 toolchain.
+* An issue for `Raspberry Pi Zero W` has been spotted with the `mender-convert` tool version 1.1.0.
+  After an initial boot, having last partition resized to the end of the SD card, the correct device
+  tree cannot be found. As a result the boot cannot succeed.
+  For more information and current status, see [issue tracker](https://tracker.mender.io/browse/MEN-2436).
 * If building U-boot fails with:
 ```
      D	scripts/Kconfig
@@ -98,7 +107,7 @@ After it finishes, you can find your images in the `output` directory on your ho
      include/linux/kconfig.h:4:32: fatal error: generated/autoconf.h: No such file or directory
      #include <generated/autoconf.h>
 ```
-you might be using a case-sensitive filesystem which is not supported. Case-sensitive filesystems are typically used on OSX (Mac) and Windows but you can also run in to this on Linux if running on a NTFS formatted partition. 
+you might be using a case-sensitive filesystem which is not supported. Case-sensitive filesystems are typically used on OSX (Mac) and Windows but you can also run in to this on Linux if running on a NTFS formatted partition.
 
 For details see this [discussion](https://hub.mender.io/t/raspberry-pi-3-model-b-b-raspbian/140/10)
 


### PR DESCRIPTION
…Raspberry Pi Zero

ARMv7 is backward compatible with ARMv6, so binaries compiled for ARMv6 should also work on ARMv7.

Changelog: Title

Issue: MEN-2399

Signed-off-by: Adam Podogrocki <a.podogrocki@gmail.com>