### PR TITLE
Bugfix/adaptions for dockerfile robustness

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -81,6 +81,10 @@ RUN env CGO_ENABLED=1 \
     GOOS=linux \
     GOARM=6 GOARCH=arm make build
 
+# allow us to keep original PATH variables when sudoing
+RUN echo "Defaults        secure_path=\"/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/snap/bin:$PATH\"" > /etc/sudoers.d/secure_path_override
+RUN chmod 0440 /etc/sudoers.d/secure_path_override
+
 WORKDIR /
 
 COPY docker-entrypoint.sh /usr/local/bin/

--- a/Dockerfile
+++ b/Dockerfile
@@ -40,7 +40,7 @@ RUN echo "mtools_skip_check=1" >> $HOME/.mtoolsrc
 RUN wget -nc -q https://toolchains.bootlin.com/downloads/releases/toolchains/armv6-eabihf/tarballs/armv6-eabihf--glibc--stable-2018.11-1.tar.bz2 \
     && tar -xjf armv6-eabihf--glibc--stable-2018.11-1.tar.bz2 \
     && rm armv6-eabihf--glibc--stable-2018.11-1.tar.bz2 \
-    && echo export PATH=$PATH:/armv6-eabihf--glibc--stable-2018.11-1/bin >> /root/.bashrc
+    && echo 'export PATH=$PATH:/armv6-eabihf--glibc--stable-2018.11-1/bin' >> /root/.bashrc
 
 RUN wget -q -O /usr/bin/mender-artifact https://d1b0l86ne08fsf.cloudfront.net/mender-artifact/$MENDER_ARTIFACT_VERSION/mender-artifact \
     && chmod +x /usr/bin/mender-artifact
@@ -48,7 +48,7 @@ RUN wget -q -O /usr/bin/mender-artifact https://d1b0l86ne08fsf.cloudfront.net/me
 # Golang environment, for cross-compiling the Mender client
 RUN wget https://dl.google.com/go/go$GOLANG_VERSION.linux-amd64.tar.gz \
     && tar -C /usr/local -xzf go$GOLANG_VERSION.linux-amd64.tar.gz \
-    && echo export PATH=$PATH:/usr/local/go/bin >> /root/.bashrc
+    && echo 'export PATH=$PATH:/usr/local/go/bin' >> /root/.bashrc
 
 ENV PATH "$PATH:/usr/local/go/bin:/armv6-eabihf--glibc--stable-2018.11-1/bin"
 ENV GOPATH "/root/go"

--- a/Dockerfile
+++ b/Dockerfile
@@ -55,6 +55,7 @@ ENV GOPATH "/root/go"
 
 # Download Mender client
 ARG mender_client_version
+RUN test -n "$mender_client_version" || (echo "Argument 'mender_client_version' is mandatory." && exit 1)
 ENV MENDER_CLIENT_VERSION=$mender_client_version
 
 RUN go get -d github.com/mendersoftware/mender


### PR DESCRIPTION
I had a few issues when using the docker image locally:

- Problems with $PATH at runtime in the docker container.
- Accidently did not set the $mender_client_version build-ARG, which resulted in an unrelated error in step 8/9 when running docker-mender-convert.

These adaptions fixed the problems for me.