### PR TITLE
always run 'image_shrink_rootfs' in 'do_from_raw_disk_image'

### DIFF
--- a/mender-convert
+++ b/mender-convert
@@ -150,8 +150,8 @@ do_raw_disk_image_shrink_rootfs() {
   elif [[ $raw_disk_counts -eq 2 ]]; then
     sudo losetup $loopdevice $raw_disk_image -o $((${raw_disk_sizes[prootfs_start]} * $sector_size))
   else
-    log "Error: invalid/unsupported embedded raw disk image. Aborting."
-    return 1
+    log "Warning: invalid/unsupported embedded raw disk image. Skipping resize..."
+    return 0
   fi
 
   block_size=($(sudo dumpe2fs -h $loopdevice | grep 'Block size' | tr -s ' ' | cut -d ' ' -f3))

--- a/mender-convert
+++ b/mender-convert
@@ -19,8 +19,6 @@ General commands:
                                                   necessary files installed
         mender-disk-image-to-artifact           - creates Mender artifact file
                                                   from Mender image
-        raw-disk-image-shrink-rootfs            - shrinks existing embedded raw
-                                                  disk image
 
 Options: [-r|--raw-disk-image | -m|--mender-disk-image | -s|--data-part-size-mb |
           -d|--device-type | -p|--rootfs-partition-id | -n|--demo | -i|--demo-host-ip |
@@ -84,13 +82,6 @@ Examples:
                 --rootfs-partition-id <primary | secondary>
 
         Note: artifact name format is: release-<release_no>_<mender_version>
-
-    To shrink the existing embedded raw disk image:
-
-        ./mender-convert raw-disk-image-shrink-rootfs
-                --raw-disk-image <raw_disk_image_path>
-
-        Output: Root filesystem size (sectors): 4521984
 
 EOF
 }
@@ -648,6 +639,9 @@ do_from_raw_disk_image() {
     return 1
   fi
 
+  do_raw_disk_image_shrink_rootfs || rc=$?
+  [[ $rc -ne 0 ]] && { return 1; }
+
   do_raw_disk_image_create_partitions || rc=$?
   [[ $rc -ne 0 ]] && { return 1; }
 
@@ -797,14 +791,6 @@ mender_rootfs_image=${output_dir}/${mender_rootfs_basename}
 mender_artifact=${output_dir}/${mender_disk_basename}.mender
 
 case "$1" in
-  raw-disk-image-shrink-rootfs)
-    total=1
-    do_raw_disk_image_shrink_rootfs || rc=$?
-    [[ $rc -ne 0 ]] && { log "Check $build_log for details."; exit 1; }
-    log "The rootfs partition in the raw disk image has been shrinked successfully!"
-    log "You can now convert the output raw disk image\n\t$raw_disk_image\
-         \nto a Mender disk image."
-    ;;
   mender-disk-image-to-artifact)
     total=1
     do_mender_disk_image_to_artifact || rc=$?


### PR DESCRIPTION
There has been a lot of confusion lately and tpyically people are
confused by these type of messages:

    *** Data partition size set to default value: 128MB ***
    1/9 Repartitioning raw disk image...
     Detected raw disk image with 2 partition(s).
     Calculating partitions' sizes of the Mender image.
     Adjust Mender disk image size to the total storage size (2048MB).
     Defined total storage size of MB is too small.
     Minimal required storage is 60056MB. Aborting.

There are two things here that are hard to understand:

- Why does it not respect the 'storage-total-size-mb' setting of 2048MB?
- Where does the 60GB requirement come frome?

This normally happens if you have booted an image once on e.g Raspbian,
which will expand the rootfs to occupy the reamining blocks of the SD
card. And if you then do a "dd" dump of that image you will get that
expanded rootfs size. We normally recommend to run
"raw-disk-image-shrink-rootfs" on these type of images before
"from-raw-disk-image" command, which will ensure that the rootfs is
reduced in size.

To remedy the confusion here, simply run the
"raw-disk-image-shrink-rootfs" unconditionally when running
"from-raw-disk-image", this way it will not matter if the input image
has been "expanded" and the '--storage-total-size-mb' will always be
respected assuming that that the actual rootfs size does not overflow
the '--storage-total-size-mb' setting.

Because 'raw-disk-image-shrink-rootfs' is now a default, we also remove
the external command for this.

Changelog: shrink expanded rootfs when running "from_raw_disk_image"

Signed-off-by: Mirza Krak <mirza.krak@northern.tech>