### PR TITLE
Enable U-Boot to select between compressed and uncompressed Kernels

### DIFF
--- a/rpi-convert-stage-5.sh
+++ b/rpi-convert-stage-5.sh
@@ -66,8 +66,16 @@ build_uboot_files() {
 	fdt addr ${fdt_addr} && fdt get value bootargs /chosen bootargs
 	run mender_setup
 	mmc dev ${mender_uboot_dev}
-	load ${mender_uboot_root} ${kernel_addr_r} /boot/zImage
-	bootz ${kernel_addr_r} - ${fdt_addr}
+	if [ -f /boot/zImage ]; then
+	  load ${mender_uboot_root} ${kernel_addr_r} /boot/zImage
+	  bootz ${kernel_addr_r} - ${fdt_addr}
+	elif [ -f /boot/uImage ]; then
+	  load ${mender_uboot_root} ${kernel_addr_r} /boot/uImage
+	  bootm ${kernel_addr_r} - ${fdt_addr}
+	else
+	  echo "No bootable Kernel found. Aborting."
+	  exit 1
+	fi
 	run mender_try_to_recover
 	EOF
 


### PR DESCRIPTION
Changelog: Instruct U-Boot to be able to boot either a compressed or an uncompressed kernel. This is very useful e.g. when switching from Debian (Raspbian) created using mender-convert to a Yocto based environment that does not compress the Kernel by default.
Signed-off-by: Simon Ensslen simon.ensslen@griesser.ch