### PR TITLE
initial support for Rockpro64 with Armbian image

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ input/
 output/
 device-image-shell/output
 mendertesting/
+integration/

--- a/convert-stage-4.sh
+++ b/convert-stage-4.sh
@@ -68,6 +68,9 @@ append_rootfs_configuration() {
   if [ "$device_type" == "qemux86_64" ]; then
     rootfsparta="/dev/hda2"
     rootfspartb="/dev/hda3"
+  elif [ "$device_type" == "rockpro64" ]; then
+    rootfsparta="/dev/mmcblk1p2"
+    rootfspartb="/dev/mmcblk1p3"
   fi
 
   jq_inplace '.RootfsPartA = \"'$rootfsparta'\" | .RootfsPartB = \"'$rootfspartb'\"' ${conffile}
@@ -75,22 +78,29 @@ append_rootfs_configuration() {
 
 create_client_files() {
   cat <<- EOF > $mender_dir/device_type
-	device_type=${device_type}
-	EOF
+device_type=${device_type}
+EOF
 
   case "$device_type" in
     "beaglebone" | "qemux86_64")
       cat <<- EOF > $mender_dir/fw_env.config
-	/dev/mmcblk0 0x800000 0x20000
-	/dev/mmcblk0 0x1000000 0x20000
-	EOF
+/dev/mmcblk0 0x800000 0x20000
+/dev/mmcblk0 0x1000000 0x20000
+EOF
       ;;
     "raspberrypi3"|"raspberrypi0w")
       cat <<- EOF > $mender_dir/fw_env.config
-	/dev/mmcblk0 0x400000 0x4000
-	/dev/mmcblk0 0x800000 0x4000
-	EOF
+/dev/mmcblk0 0x400000 0x4000
+/dev/mmcblk0 0x800000 0x4000
+EOF
       ;;
+    "rockpro64")
+      cat <<- EOF > $mender_dir/fw_env.config
+/dev/mmcblk1 0x400000 0x8000
+/dev/mmcblk1 0x800000 0x8000
+EOF
+      ;;
+
   esac
 }
 

--- a/convert-stage-5.sh
+++ b/convert-stage-5.sh
@@ -36,6 +36,7 @@ EOF
 
 tool_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 output_dir=${tool_dir}/output
+integration_dir=${tool_dir}/integration
 grub_dir=$output_dir/grub
 grubenv_dir=$output_dir/grubenv
 mender_disk_image=
@@ -109,6 +110,10 @@ build_env_lock_boot_files() {
 #
 #  $1 - linux kernel version
 build_grub_efi() {
+  if [ "$device_type" == "rockpro64" ]; then
+    return 0
+  fi
+
   log "\tBuilding GRUB efi file."
 
   local grub_build_dir=$grub_dir/build
@@ -210,6 +215,15 @@ install_files() {
   local boot_dir=$1
   local rootfs_dir=$2
   local linux_version=$3
+
+  if [ "$device_type" == "rockpro64" ]; then
+    cp $integration_dir/rockpro64/boot.scr ${boot_dir}/
+
+    # It is not possible to resize rootfs part when using Mender. so disable
+    # the service
+    touch ${rootfs_dir}/root/.no_rootfs_resize
+    return 0
+  fi
 
   local grub_build_dir=$grub_dir/build
   local grub_arm_dir=$grub_build_dir/arm

--- a/mender-convert
+++ b/mender-convert
@@ -123,7 +123,7 @@ declare -a rootfs_partition_ids=("primary" "secondary")
 declare -a mender_disk_mappings
 declare -a raw_disk_mappings
 #Supported devices
-declare -a supported_devices=("beaglebone" "raspberrypi3" "qemux86_64" "raspberrypi0w")
+declare -a supported_devices=("beaglebone" "raspberrypi3" "qemux86_64" "raspberrypi0w" "rockpro64")
 
 do_raw_disk_image_shrink_rootfs() {
   log "$step/$total Shrinking raw disk image root filesystem..."
@@ -297,6 +297,9 @@ do_raw_disk_image_create_partitions() {
     "qemux86_64")
       do_make_sdimg_qemux86_64
       ;;
+    "rockpro64")
+      do_make_sdimg_rockpro64
+      ;;
     *)
       log "Error: unsupported device type $device_type"
       exit 1
@@ -317,6 +320,39 @@ do_raw_disk_image_create_partitions() {
   [ $rc -eq 0 ] || { log "\nRepartitioning of $raw_disk_image image failed."; }
 
   return $rc
+}
+
+do_make_sdimg_rockpro64() {
+  local ret=0
+
+  create_device_maps $raw_disk_image raw_disk_mappings
+  mount_raw_disk ${raw_disk_mappings[@]}
+
+  log "$step/$total Setting boot partition..."
+  ((step++))
+
+  stage_2_args="$output_dir ${mender_disk_mappings[0]} ${embedded_rootfs_dir}"
+  ${tool_dir}/rockpro64-convert-stage-2.sh ${stage_2_args} || ret=$?
+  [[ $ret -ne 0 ]] && { log "Aborting."; return $ret; }
+
+  log "$step/$total Setting root filesystem partition..."
+  ((step++))
+
+  stage_3_args="$output_dir ${mender_disk_mappings[1]}"
+  ${tool_dir}/convert-stage-3.sh ${stage_3_args} || ret=$?
+  [[ $ret -ne 0 ]] && { return $ret; }
+
+  mount_mender_disk ${mender_disk_mappings[@]}
+
+  log "$step/$total Setting file system table..."
+  ((step++))
+  set_fstab $device_type
+
+  log "Write bootloader"
+  dd if=$integration_dir/rockpro64/rksd_loader.img of=$mender_disk_image \
+     seek=64 conv=notrunc status=none
+
+  return $ret
 }
 
 do_make_sdimg_beaglebone() {
@@ -469,7 +505,7 @@ do_install_bootloader_to_mender_disk_image() {
       { log "Error: incorrect device type. Aborting."; return 1; }
 
   case "$device_type" in
-    "beaglebone" | "qemux86_64")
+    "beaglebone" | "qemux86_64" | "rockpro64")
       stage_5_args="-m $mender_disk_image -d $device_type -b ${bootloader_toolchain} $keep"
       eval set -- " ${stage_5_args}"
       ${tool_dir}/convert-stage-5.sh ${stage_5_args}|| ret=$?
@@ -766,6 +802,21 @@ eval set -- "$PARAMS"
 # and configure where logs should be redirected.
 mkdir -p $output_dir
 logsetup
+
+# Fetch integration binaries
+
+MENDER_INTEGRATION_URL="https://d1b0l86ne08fsf.cloudfront.net/mender-convert"
+if [ "$device_type" == "rockpro64" ]; then
+  if [ ! -f $integration_dir/rockpro64/emmc-boot-integration.tar.gz ]; then
+    rockpro64_integration_dir=$integration_dir/rockpro64
+
+    mkdir -p $rockpro64_integration_dir
+    wget -P $rockpro64_integration_dir \
+           ${MENDER_INTEGRATION_URL}/armbian/rockpro64/emmc-boot-integration.tar.gz
+
+    tar xvf $rockpro64_integration_dir/emmc-boot-integration.tar.gz -C $rockpro64_integration_dir
+  fi
+fi
 
 # Some commands expect elevated privileges.
 sudo true

--- a/mender-convert-functions.sh
+++ b/mender-convert-functions.sh
@@ -31,6 +31,7 @@ declare -A mender_disk_sizes
 tool_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 files_dir=${tool_dir}/files
 output_dir=${tool_dir}/output
+integration_dir=${tool_dir}/integration
 build_log=${output_dir}/build.log
 
 embedded_base_dir=$output_dir/embedded
@@ -206,7 +207,7 @@ set_mender_disk_alignment() {
       local lvar_partition_alignment=${PART_ALIGN_8MB}
       local lvar_vfat_storage_offset=$lvar_partition_alignment
       ;;
-    "raspberrypi3" | "raspberrypi0w")
+    "raspberrypi3" | "raspberrypi0w" | "rockpro64")
       local lvar_partition_alignment=${PART_ALIGN_4MB}
       local lvar_uboot_env_size=$(( $lvar_partition_alignment * 2 ))
       local lvar_vfat_storage_offset=$(( $lvar_partition_alignment + $lvar_uboot_env_size ))
@@ -766,6 +767,10 @@ set_fstab() {
     "raspberrypi3"|"raspberrypi0w")
       mountpoint="/uboot"
       blk_device=mmcblk0p
+      ;;
+    "rockpro64")
+      mountpoint="/uboot"
+      blk_device=mmcblk1p
       ;;
     "qemux86_64")
       mountpoint="/boot/efi"

--- a/rockpro64-convert-stage-2.sh
+++ b/rockpro64-convert-stage-2.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+output_dir=$1
+boot_mapping=$2
+embedded_rootfs_dir=$3
+uboot_backup_dir=${embedded_rootfs_dir}/opt/backup/uboot
+build_log=$output_dir/build.log
+
+boot_part_dev="/dev/mapper/${boot_mapping}"
+
+[ ! -f $output_dir/boot.vfat ] && \
+    { log "Error: extracted boot partition not found. Aborting."; exit 1; }
+[ ! -d "${embedded_rootfs_dir}" ] && \
+    { log "Error: embedded content not mounted."; exit 1; }
+[ ! -e ${boot_part_dev} ] && \
+    { log "Error: boot part does not exist: ${boot_part_dev}."; exit 1; }
+
+sudo dd if=${output_dir}/boot.vfat of=${boot_part_dev} bs=1M conv=sparse >> "$build_log" 2>&1
+
+log "\tDone."
+
+exit 0


### PR DESCRIPTION
Note that this integration relies on an "standard" U-boot integration,
but the binaries are not built in mender-convert and instead it
relies on fetching pre-built binaries.

Changelog: Support for RockPro64 board

Signed-off-by: Mirza Krak <mirza.krak@northern.tech>