### PR TITLE
add path to server.crt to mender.conf

### DIFF
--- a/convert-stage-4.sh
+++ b/convert-stage-4.sh
@@ -202,6 +202,7 @@ install_files() {
   # Install provided or demo certificate
   if [ -n "${server_cert}" ]; then
     sudo install -m 0444 ${server_cert} ${primary_dir}/${sysconfdir}/server.crt
+    jq_inplace '.ServerCertificate = \"$'{primary_dir}'/'${sysconfdir}'/server.crt\"' ${primary_dir}/${sysconfdir}/mender.conf 
   else
     sudo install -m 0444 ${mender_dir}/server.demo.crt ${primary_dir}/${sysconfdir}/server.crt
   fi


### PR DESCRIPTION
Currently, if you follow the tutorial on how to convert existing Debian image, it won't work with self-hosted Mender servers because the corresponding field is not getting added to `mender.conf`.

This PR fixes this. Yet I understand that it's probably not the most proper solution, maybe a line should be added in the default `mender.conf` template. 