### PR TITLE
MEN-2673: mender-convert on Raspbian buster 2019-07-10 does not boot

### DIFF
--- a/files/init_resize.sh
+++ b/files/init_resize.sh
@@ -88,6 +88,10 @@ mount -t sysfs sys /sys
 
 mount /uboot
 sed -i 's| init=/usr/lib/raspi-config/init_resize.sh||' /uboot/cmdline.txt
+sed -i 's| sdhci\.debug_quirks2=4||' ${output_dir}/cmdline.txt
+if ! grep -q splash /uboot/cmdline.txt; then
+  sed -i "s/ quiet//g" /uboot/cmdline.txt
+fi
 mount /uboot -o remount,ro
 sync
 

--- a/rpi-convert-stage-2.sh
+++ b/rpi-convert-stage-2.sh
@@ -7,17 +7,6 @@ build_log=$output_dir/build.log
 [ ! -f $output_dir/boot.vfat ] && \
     { log "Error: extracted boot partition not found. Aborting."; exit 1; }
 
-# Make a copy of Linux kernel arguments and modify.
-mcopy -on -i ${output_dir}/boot.vfat -s ::cmdline.txt ${output_dir}/cmdline.txt
-sed -i 's/\b[ ]root=[^ ]*/ root=\/dev\/mmcblk0p2/' ${output_dir}/cmdline.txt
-sed -i 's/\b[ ]console=tty1//' ${output_dir}/cmdline.txt
-# Update Linux kernel command arguments with our custom configuration
-mcopy -o -i ${output_dir}/boot.vfat -s ${output_dir}/cmdline.txt ::cmdline.txt
-
-mcopy -on -i ${output_dir}/boot.vfat -s ::config.txt ${output_dir}/config.txt
-echo -e '\nenable_uart=1\n' >> ${output_dir}/config.txt
-mcopy -o -i ${output_dir}/boot.vfat -s ${output_dir}/config.txt ::config.txt
-
 sudo dd if=${output_dir}/boot.vfat of=/dev/mapper/${boot_mapping} bs=1M conv=sparse >> "$build_log" 2>&1
 
 log "\tDone."

--- a/rpi-convert-stage-5.sh
+++ b/rpi-convert-stage-5.sh
@@ -138,14 +138,6 @@ install_files() {
 
   sudo cp ${bin_dir_pi}/boot.scr ${boot_dir}
 
-  sudo cp ${boot_dir}/config.txt ${output_dir}/config.txt
-
-  # dtoverlays seems to break U-boot for some reason, simply remove all of
-  # them as they do not actually work when U-boot is used.
-  sed -i /^dtoverlay=/d ${output_dir}/config.txt
-
-  sudo cp ${output_dir}/config.txt ${boot_dir}/config.txt
-
   # Raspberry Pi configuration files, applications expect to find this on
   # the device and in some cases parse the options to determinate
   # functionality.


### PR DESCRIPTION
For additional background information see [MEN-2673](https://tracker.mender.io/browse/MEN-2673)