### PR TITLE
install /etc/mender/script/version file

### DIFF
--- a/convert-stage-4.sh
+++ b/convert-stage-4.sh
@@ -56,6 +56,8 @@ server_cert=
 tenant_token=
 # Mender tenant token.
 mender_tenant_token="dummy"
+# Mender state-script format version
+mender_state_scripts_version="3"
 
 declare -a mender_disk_mappings
 
@@ -129,6 +131,9 @@ install_files() {
   # Prepare 'data' partition
   sudo install -d -m 755 ${data_dir}/${dataconfdir}
   sudo install -d -m 755 ${data_dir}/${databootdir}
+
+  sudo install -d -m 755 ${primary_dir}/${sysconfdir}/scripts/
+  echo -n "${mender_state_scripts_version}" | sudo tee ${primary_dir}/${sysconfdir}/scripts/version
 
   sudo install -m 0444 ${mender_dir}/device_type ${data_dir}/${dataconfdir}
   sudo install -m 0644 ${mender_dir}/fw_env.config ${data_dir}/${databootdir}


### PR DESCRIPTION
This file needs to be present for state-scripts to work as the format
version will be validated using the information provided in this file
and the version in the Mender Artifact.

"3" means that it will only accept state-scripts created using
Mender Artifact version 3.

Changelog: Title

Signed-off-by: Mirza Krak <mirza.krak@northern.tech>