### PR TITLE
fix variable expansions for /etc/mender/servert.crt path

### DIFF
--- a/convert-stage-4.sh
+++ b/convert-stage-4.sh
@@ -206,7 +206,7 @@ install_files() {
   fi
 
   if [ -e "${primary_dir}/${sysconfdir}/server.crt" ]; then
-    jq_inplace '.ServerCertificate = \"'${primary_dir}'/'${sysconfdir}'/server.crt\"' ${primary_dir}/${sysconfdir}/mender.conf
+    jq_inplace '.ServerCertificate = \"/'${sysconfdir}'/server.crt\"' ${primary_dir}/${sysconfdir}/mender.conf
   fi
 }
 


### PR DESCRIPTION
Currently the code expands to the following in mender.conf:

     /mender-convert/output/sdimg/primary/etc/mender/server.crt

${primary_dir} should be dropped from assignment

Fixes: d5e861b052e5 ("add ServerCertificate entry in mender.conf if servert.crt was installed")

Changelog: None

Signed-off-by: Mirza Krak <mirza.krak@northern.tech>