### PR TITLE
README: update URL to Mender logo

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ image by restructuring partition table and injecting the necessary files.
 
 Currently official Raspberry Pi 3 and BeagleBone Black images are supported and this will be extended.
 
-![Mender logo](https://mender.io/user/pages/resources/06.digital-assets/mender.io.png)
+![Mender logo](https://github.com/mendersoftware/mender/raw/master/mender_logo.png)
 
 ## Getting started
 


### PR DESCRIPTION
It was pointing to a resource on mender.io, which duo to recent
website updates was moved/removed.

Update the URL to use the logo that is present in mendersoftware/mender,
which hopefully will not move as much.

Changelog: None

Signed-off-by: Mirza Krak <mirza.krak@northern.tech>