### PR TITLE
scripts: run-tests: ensure that multi-config code path is executed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@ work
 rootfs_overlay_demo/*
 tests
 mender_local_config
+*.xml
+*.html

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -55,7 +55,7 @@ test_acceptance:
     - docker version
     # Install dependencies
     - apk --update --no-cache add bash wget git util-linux mtools python
-      py-pip gcc python2-dev libffi-dev libc-dev openssl-dev make
+      py-pip gcc python2-dev libffi-dev libc-dev openssl-dev make sudo
     - pip install "pytest>=3.0" "Fabric>=1.13.0, <2" pytest-html
     # Load image under test
     - export IMAGE_NAME=$DOCKER_REPOSITORY:pr

--- a/mender-convert-extract
+++ b/mender-convert-extract
@@ -19,7 +19,8 @@ echo "Running $(basename $0): $@"
 source modules/bootstrap.sh
 source modules/disk.sh
 
-declare -a configs
+# The mender_convert_config is always used and provides all the defaults
+declare -a configs=("configs/mender_convert_config")
 
 disk_image=""
 while (( "$#" )); do

--- a/mender-convert-modify
+++ b/mender-convert-modify
@@ -39,7 +39,8 @@ source modules/bootstrap.sh
 source modules/disk.sh
 source modules/probe.sh
 
-declare -a configs
+# The mender_convert_config is always used and provides all the defaults
+declare -a configs=("configs/mender_convert_config")
 
 while (( "$#" )); do
   case "$1" in

--- a/mender-convert-package
+++ b/mender-convert-package
@@ -38,7 +38,8 @@ echo "Running $(basename $0): $@"
 source modules/bootstrap.sh
 source modules/disk.sh
 
-declare -a configs
+# The mender_convert_config is always used and provides all the defaults
+declare -a configs=("configs/mender_convert_config")
 
 while (( "$#" )); do
   case "$1" in

--- a/modules/config.sh
+++ b/modules/config.sh
@@ -16,7 +16,6 @@
 
 # Read in the array of config files to process
 read -a configs <<< "${@}"
-configs=( "configs/mender_convert_config" "${configs[@]}" )
 for config in "${configs[@]}"; do
     log_info "Using configuration file: ${config}"
     source "${config}"

--- a/scripts/README-run-tests.md
+++ b/scripts/README-run-tests.md
@@ -1,13 +1,16 @@
 # Run tests
 
-Run the following commands to install test dependencies (assumes that all mender-convert dependencies are already installed):
+The tests utilize the provided Docker container in this repository and conversion
+is done using the `docker-mender-convert` command. For this reason we first need
+to build the container (commands must be run from the root directory of
+`mender-convert`):
 
-    sudo apt-get update e2fsprogs=1.44.1-1
-    sudo apt-get -qy --force-yes install python-pip
-    sudo pip2 install pytest --upgrade
-    sudo pip2 install pytest-xdist --upgrade
-    sudo pip2 install pytest-html --upgrade
+```bash
+./docker-build
+```
 
 Run tests:
 
-    ./scripts/run-tests.sh
+```bash
+./scripts/run-tests.sh
+```


### PR DESCRIPTION
This is a follow-up to https://github.com/mendersoftware/mender-convert/pull/119.