### PR TITLE
rpi: bump U-Boot version

### DIFF
--- a/rpi-convert-stage-5.sh
+++ b/rpi-convert-stage-5.sh
@@ -34,7 +34,7 @@ build_uboot_files() {
   local CROSS_COMPILE=${1}-
   local ARCH=arm
   local branch="mender-rpi-2018.07"
-  local commit="884893e54a"
+  local commit="50f05ab10e"
   local uboot_repo_vc_dir=$uboot_dir/.git
   local defconfig="rpi_3_32b_defconfig"
 


### PR DESCRIPTION
This includes only one change:

     2a8a20f01d4 Disable addition of simple-framebuffer by U-boot

Fixes: MEN-2685

Changelog: Fix "yellow" HDMI output on Raspbian Buster

Signed-off-by: Mirza Krak <mirza.krak@northern.tech>