### PR TITLE
Switch to master deb packages and update URL accordingly

### DIFF
--- a/configs/mender_convert_config
+++ b/configs/mender_convert_config
@@ -88,7 +88,7 @@ MENDER_PARTITION_ALIGNMENT="8388608"
 # Mender client version
 #
 # This is used to fetch the correct binaries
-MENDER_CLIENT_VERSION="2.0.1"
+MENDER_CLIENT_VERSION="master"
 
 # File storage, containing binary files, do not modify this unless you know
 # what you are doing.

--- a/mender-convert-modify
+++ b/mender-convert-modify
@@ -84,7 +84,7 @@ log_info "Installing Mender client and related files"
 
 deb_arch=$(probe_debian_arch_name)
 deb_name="mender-client_${MENDER_CLIENT_VERSION}-1_${deb_arch}.deb"
-run_and_log_cmd "wget -Nq ${MENDER_STORAGE_URL}/mender-convert/deb/${deb_name} -P work/mender-deb"
+run_and_log_cmd "wget -Nq ${MENDER_STORAGE_URL}/${MENDER_CLIENT_VERSION}/dist-packages/debian/${deb_arch}/${deb_name} -P work/mender-deb"
 
 cd work/mender-deb
 run_and_log_cmd "ar -xv ${deb_name}"


### PR DESCRIPTION
Now that the Debian packages are generated for the three architectures,
abandon the temporary location and switch to the master ones.

After the next Mender release, we can switch to the "released" packages.