### PR TITLE
QA-120: Update acceptance tests to Python3

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -40,9 +40,10 @@ test_acceptance:
     - export DOCKER_HOST="unix:///var/run/docker.sock"
     - docker version
     # Install dependencies
-    - apk --update --no-cache add bash wget git util-linux mtools python
-      py-pip gcc python2-dev libffi-dev libc-dev openssl-dev make sudo
-    - pip install "pytest>=3.0" "Fabric>=1.13.0, <2" pytest-html
+    - apk --update --no-cache add bash wget git util-linux mtools python3 py3-pip
+      gcc python3-dev libffi-dev lzo-dev libc-dev openssl-dev make sudo
+    # Python3 dependencies
+    - pip3 install -r https://raw.githubusercontent.com/mendersoftware/meta-mender/master/tests/acceptance/requirements_py3.txt
     # Load image under test
     - export IMAGE_NAME=$DOCKER_REPOSITORY:pr
     - docker load -i image.tar

--- a/scripts/run-tests.sh
+++ b/scripts/run-tests.sh
@@ -85,7 +85,7 @@ convert_and_test() {
         --disk-image input/${image_name} \
         ${MENDER_CONVERT_EXTRA_ARGS}
 
-    if pip list | grep -q -e pytest-html; then
+    if pip3 list | grep -q -e pytest-html; then
         html_report_args="--html=${MENDER_CONVERT_DIR}/report_${device_type}.html --self-contained-html"
     fi
 
@@ -99,7 +99,7 @@ convert_and_test() {
 
     cd ${WORKSPACE}/mender-image-tests
 
-    python2 -m pytest --verbose \
+    python3 -m pytest --verbose \
             --junit-xml="${MENDER_CONVERT_DIR}/results_${device_type}.xml" \
             ${html_report_args} \
             --test-conversion \


### PR DESCRIPTION
Basically install dependencies and modify pytest call. This repo is
using meta-mender master test framework, so the actual tests are already
converted and working fine.