### PR TITLE
Bump Go to 1.13.4

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM ubuntu:18.04
 
 ARG MENDER_ARTIFACT_VERSION=3.2.0
-ARG GOLANG_VERSION=1.11.2
+ARG GOLANG_VERSION=1.13.4
 
 RUN apt-get update && apt-get install -y \
     kpartx \


### PR DESCRIPTION
See https://golang.org/doc/devel/release.html for Go release notes.
I also suggest to subscribe to https://groups.google.com/group/golang-announce to stay up to date with the regular and out of schedule releases.