### PR TITLE
Add support for custom overlays and state scripts.

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,35 @@ You can watch `output/build.log` for progress and diagnostics information.
 After it finishes, you can find your images in the `output` directory on your host machine!
 
 
+### Customizing the image
+`mender-convert` allows custom files to be added to the image after all processing has taken place but before the artifact is created. This is done using the following command line options:
+* `--rootfs-overlay`: Add files to the rootfs partition.
+* `--boot-overlay`: Add files to the boot partition.
+* `--data-overlay`: Add files to the data partition.
+
+To use this feature, create a new directory under the directory where you copied these files and place the files to be copied inside, making sure that the directory structure and permissions are how they should be on the target file system. Then, pass the directory path to `mender-convert` using one of the above command line options.
+
+E.g. With the following file structure created for a rootfs overlay:
+
+```
+rootfs/
+├── [drwxr-xr-x pi     ]  etc
+│   └── [-rw------- root    ]  testfile
+└── [drwxr-xr-x pi     ]  home
+    └── [drwxr-xr-x pi     ]  pi
+        ├── [-rw-r--r-- pi     ]  file1
+        ├── [-rw-r--r-- pi     ]  file2
+        └── [-rw-r--r-- pi     ]  file3
+```
+and `mender-convert` called with the following additional option:
+
+```
+mender-convert ..... --rootfs-overlay rootfs/
+```
+
+...the contents of the `rootfs` folder would be copied as-is to the root directory of the rootfs partition, resulting in `testfile` present under `/etc/` and `file1 file2 file3` under `/home/pi/`, with all the file attributes preserved.
+
+
 ### Known issues
 * An issue for `Raspberry Pi Zero W` has been spotted with the `mender-convert` tool version 1.1.0.
   After an initial boot, having last partition resized to the end of the SD card, the correct device

--- a/convert-stage-6.sh
+++ b/convert-stage-6.sh
@@ -1,0 +1,107 @@
+#!/bin/bash
+
+set -e
+
+show_help() {
+  cat << EOF
+
+Custom user files installer.
+
+Usage: $0 [options]
+
+    Options: [-m|--mender-disk-image -r|--rootfs-overlay | -b|--boot-overlay | -d|--data-overlay -h|--help]
+
+        --mender-disk-image - Mender raw disk image
+        --rootfs-overlay      - Path to rootfs overlay
+        --boot-overlay      - Path to boot partition overlay
+        --data-overlay      - Path to data partition overlay
+        --help              - Show help and exit
+
+    For examples, see: ./mender-convert --help
+
+EOF
+  exit 1
+}
+
+declare -a mender_disk_mappings
+
+tool_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+do_install_overlay() {
+    local source=$1
+    local loopback=$2
+
+    local map_dest=/dev/mapper/"${loopback}"
+    local path_dest=$output_dir/${loopback}
+    mkdir -p ${path_dest}
+
+    sudo mount ${map_dest} ${path_dest}
+
+    # Attempt to copy the files, preserving attributes.
+    # If this fails (e.g. because the file system is vfat)
+    # then copy without preserving attributes
+    sudo cp -a ${source}/* ${path_dest} 2>/dev/null || log "\t\t\tfiles copied without preserving attributes" && sudo cp -r ${source}/* ${path_dest}
+
+    sudo umount ${map_dest}
+    rmdir ${path_dest}
+}
+
+do_install_overlays() {
+    if [ -z "${mender_disk_image}" ]; then
+        log "Mender raw disk image not set. Aborting."
+        show_help
+    fi
+
+    create_device_maps $mender_disk_image mender_disk_mappings
+
+    if [ -n "${boot_overlay}" ]; then
+        log "\t\tInstalling boot overlay..."
+        do_install_overlay ${boot_overlay} ${mender_disk_mappings[0]}
+    fi
+
+    if [ -n "${rootfs_overlay}" ]; then
+        log "\t\tInstalling rootfs overlay..."
+        do_install_overlay ${rootfs_overlay} ${mender_disk_mappings[1]}
+    fi
+
+    if [ -n "${data_overlay}" ]; then
+        log "\t\tInstalling data overlay..."
+        do_install_overlay ${data_overlay} ${mender_disk_mappings[3]}
+    fi
+
+    # Cleanup
+    detach_device_maps ${mender_disk_mappings[@]}
+    log "\tOverlays installed."
+}
+
+while (( "$#" )); do
+  case "$1" in
+    -m | --mender-disk-image)
+      mender_disk_image=$2
+      shift 2
+      ;;
+    -r | --rootfs-overlay)
+      rootfs_overlay=$2
+      shift 2
+      ;;
+    -b | --boot-overlay)
+      boot_overlay=$2
+      shift 2
+      ;;
+    -d | --data-overlay)
+      data_overlay=$2
+      shift 2
+      ;;
+    -h | --help)
+      show_help
+      ;;
+    -*)
+      log "Error: unsupported option $1"
+      exit 1
+      ;;
+  esac
+done
+
+cd ${tool_dir}
+
+do_install_overlays

--- a/mender-convert
+++ b/mender-convert
@@ -24,6 +24,7 @@ Options: [-r|--raw-disk-image | -m|--mender-disk-image | -s|--data-part-size-mb 
           -d|--device-type | -p|--rootfs-partition-id | -n|--demo | -i|--demo-host-ip |
           -c|--server-cert | -u|--server-url | -t|--tenant-token |
           -g|--mender-client | -b|--bootloader-toolchain | -a|--artifact-name |
+          -R|--rootfs-overlay | -B|--boot-overlay | -D|--data-overlay | -S|--state-script |
           -e|--storage-total-size-mb | -k|--keep | -v|--version -h|--help]
 
         raw-disk-image        - raw disk embedded Linux (Debian, Raspbian,
@@ -43,6 +44,11 @@ Options: [-r|--raw-disk-image | -m|--mender-disk-image | -s|--data-part-size-mb 
         mender-client         - Mender client binary
         bootloader-toolchain  - GNU Arm Embedded Toolchain
         artifact-name         - Mender artifact name
+        rootfs-overlay        - Path to rootfs overlay
+        boot-overlay          - Path to boot partition overlay
+        data-overlay          - Path to data partition overlay
+        state-script          - Path to state script to be included in artifact. 
+                                Can be specified multiple times to include multiple scripts.
         storage-total-size-mb - total storage size in MB; default value 8000MB;
                                 it is used to calculate the rootfs final size
         keep                  - keep intermediate files in output directory
@@ -533,6 +539,38 @@ do_install_bootloader_to_mender_disk_image() {
   return 0
 }
 
+do_install_custom_files_to_mender_image() {
+  log "$step/$total Installing custom files..."
+  ((step++))
+
+  if [ -z "${mender_disk_image}" ]; then
+    log "Mender disk image not set. Aborting."
+    return 1
+  fi
+
+  stage_6_args=
+
+  if [ -n "${rootfs_overlay}" ]; then
+    stage_6_args="${stage_6_args} -r ${rootfs_overlay}"
+  fi
+
+  if [ -n "${boot_overlay}" ]; then
+    stage_6_args="${stage_6_args} -b ${boot_overlay}"
+  fi
+
+  if [ -n "${data_overlay}" ]; then
+    stage_6_args="${stage_6_args} -d ${data_overlay}"
+  fi
+
+  if [ -n "${stage_6_args}" ]; then
+      stage_6_args="-m $mender_disk_image ${stage_6_args}"
+      ${tool_dir}/convert-stage-6.sh ${stage_6_args} || ret=$?
+      [[ $ret -ne 0 ]] && { log "\nInstalling custom files failed."; return $ret; }
+  fi
+
+  return 0
+}
+
 do_mender_disk_image_to_artifact() {
   log "$step/$total Creating Mender Artifact..."
   ((step++))
@@ -642,6 +680,13 @@ do_mender_disk_image_to_artifact() {
       log "\tWriting Mender artifact to: ${mender_artifact}"
       log "\tThis may take 10-20 minutes (using LZMA)..."
 
+      state_script_args=
+      if [ -n "${state_scripts}" ]; then
+        for s in "${state_scripts[@]}"; do
+          state_script_args="${state_script_args} -s ${tool_dir}/${s}"
+        done
+      fi
+      
       #Create Mender artifact
       mender-artifact \
         --compression lzma \
@@ -649,7 +694,8 @@ do_mender_disk_image_to_artifact() {
         --file ${mender_rootfs_image} \
         --output-path ${mender_artifact} \
         --artifact-name ${artifact_name} \
-        --device-type ${device_type}
+        --device-type ${device_type} \
+        ${state_script_args}
 
       ret=$?
       [[ $ret -eq 0 ]] && \
@@ -683,6 +729,9 @@ do_from_raw_disk_image() {
   [[ $rc -ne 0 ]] && { return 1; }
 
   do_install_bootloader_to_mender_disk_image || rc=$?
+  [[ $rc -ne 0 ]] && { return 1; }
+
+  do_install_custom_files_to_mender_image || rc=$?
   [[ $rc -ne 0 ]] && { return 1; }
 
   do_mender_disk_image_to_artifact || rc=$?
@@ -754,6 +803,22 @@ while (( "$#" )); do
       ;;
     -t | --tenant-token)
       tenant_token=$2
+      shift 2
+      ;;
+    -R | --rootfs-overlay)
+      rootfs_overlay=$2
+      shift 2
+      ;;
+    -B | --boot-overlay)
+      boot_overlay=$2
+      shift 2
+      ;;
+    -D | --data-overlay)
+      data_overlay=$2
+      shift 2
+      ;;
+    -S | --state-script)
+      state_scripts+=("${2}")
       shift 2
       ;;
     -e | --storage-total-size-mb)
@@ -848,7 +913,7 @@ case "$1" in
     log "You can find the Mender Artifact at:\n\t$mender_artifact\nand use it to deploy updates."
     ;;
   from-raw-disk-image)
-    total=10
+    total=11
     do_from_raw_disk_image || rc=$?
     [[ $rc -ne 0 ]] && { log "Check $build_log for details."; exit 1; }
     log "Conversion complete!"


### PR DESCRIPTION
Using the --rootfs-overlay, --boot-overlay and --data-overlay
command line options, custom files can be integrated into the
artifact, after all processing is done and right before the artifact
is created.

Using the --state-script option, multiple state scripts can be
integrated into the artifact.

Signed-off-by: Amr Bekhit <amr@helmpcb.com>