### PR TITLE
Revert "MEN-2927: Make sure `.mender` file is uploaded for use in tutorial."

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -112,10 +112,7 @@ publish:s3:
   stage: publish
   image: debian:buster
   before_script:
-    - apt update && apt install -yyq awscli curl
-
-    - curl -Lo /usr/bin/mender-artifact https://d1b0l86ne08fsf.cloudfront.net/mender-artifact/${MENDER_ARTIFACT_VERSION}/linux/mender-artifact
-    - chmod ugo+x /usr/bin/mender-artifact
+    - apt update && apt install -yyq awscli
 
     # Fetch artifacts from temporary S3 bucket
     - aws s3 cp s3://mender-gitlab-tmp-storage/$CI_PROJECT_NAME/$CI_PIPELINE_ID/deploy.tar.gz deploy.tar.gz
@@ -130,9 +127,3 @@ publish:s3:
         s3://$S3_BUCKET_NAME/${RASPBIAN_NAME}/arm/${RASPBIAN_NAME}-mender-${MENDER_CLIENT_VERSION}.img.xz
     - aws s3api put-object-acl --acl public-read --bucket $S3_BUCKET_NAME
         --key ${RASPBIAN_NAME}/arm/${RASPBIAN_NAME}-mender-${MENDER_CLIENT_VERSION}.img.xz
-
-    - mender-artifact modify -n release-1 deploy/raspberrypi-${RASPBIAN_NAME}-mender-${MENDER_CLIENT_VERSION}.mender
-    - aws s3 cp deploy/raspberrypi-${RASPBIAN_NAME}-mender-${MENDER_CLIENT_VERSION}.mender
-        s3://$S3_BUCKET_NAME/${RASPBIAN_NAME}/arm/${RASPBIAN_NAME}-mender-${MENDER_CLIENT_VERSION}_release-1.mender
-    - aws s3api put-object-acl --acl public-read --bucket $S3_BUCKET_NAME
-        --key ${RASPBIAN_NAME}/arm/${RASPBIAN_NAME}-mender-${MENDER_CLIENT_VERSION}_release-1.mender


### PR DESCRIPTION
It turns out we will not use this after all, because the artifact
won't work properly without `mender setup`, which requires a live
device. We will revisit this and use a different approach once the
`mender snapshot` feature has been developed and merged.

This reverts commit 4cfc7bc648e3bc7b1d6710fcea44f35eb642c30a.

Changelog: None
Signed-off-by: Kristian Amlie <kristian.amlie@northern.tech>