### PR TITLE
MEN-2794: Adjust the expected S3 locations for the binaries

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -113,11 +113,9 @@ publish:s3:
   image: debian:buster
   before_script:
     - apt update && apt install -yyq awscli
-
     # Fetch artifacts from temporary S3 bucket
     - aws s3 cp s3://mender-gitlab-tmp-storage/$CI_PROJECT_NAME/$CI_PIPELINE_ID/deploy.tar.gz deploy.tar.gz
     - tar xzf deploy.tar.gz
-
   script:
     - echo "Publishing ${RASPBIAN_NAME}-mender-${MENDER_CLIENT_VERSION}.img.xz version to S3"
     # Prepare high privilege S3 keys (the base keys are for the tmp storage only)
@@ -127,3 +125,5 @@ publish:s3:
         s3://$S3_BUCKET_NAME/${RASPBIAN_NAME}/arm/${RASPBIAN_NAME}-mender-${MENDER_CLIENT_VERSION}.img.xz
     - aws s3api put-object-acl --acl public-read --bucket $S3_BUCKET_NAME
         --key ${RASPBIAN_NAME}/arm/${RASPBIAN_NAME}-mender-${MENDER_CLIENT_VERSION}.img.xz
+  only:
+    - /^(master|[0-9]+\.[0-9]+\.x)$/

--- a/configs/beaglebone_black_base_config
+++ b/configs/beaglebone_black_base_config
@@ -1,7 +1,5 @@
 # Binaries generated with the following script:
-#
-#    https://github.com/drewmoseley/mender-convert-integration-scripts/blob/master/build-uboot-bbb.sh
-#
+#    https://github.com/mendersoftware/mender-convert-integration-scripts/blob/master/build-uboot-bbb.sh
 
 # There are reported issues with GRUB bootloader integration, fallback to U-boot.
 MENDER_GRUB_EFI_INTEGRATION=n
@@ -12,7 +10,8 @@ MENDER_COPY_BOOT_GAP=n
 # 4MB alignment
 MENDER_PARTITION_ALIGNMENT="4194304"
 
-BEAGLEBONE_BLACK_BINARIES_URL="${MENDER_STORAGE_URL}/mender-convert/beaglebone/${BEAGLEBONE_BLACK_BINARIES}"
+BEAGLEBONE_BLACK_BINARIES="${BEAGLEBONE_BLACK_CONFIG}-2018.07.004.tar"
+BEAGLEBONE_BLACK_BINARIES_URL="${MENDER_STORAGE_URL}/mender-convert/uboot/beaglebone/${BEAGLEBONE_BLACK_BINARIES}"
 
 function platform_modify() {
   mkdir -p work/bbb/binaries

--- a/configs/beaglebone_black_debian_emmc_config
+++ b/configs/beaglebone_black_debian_emmc_config
@@ -1,8 +1,7 @@
 # Binaries generated with the following script:
-#
-#    https://github.com/drewmoseley/mender-convert-integration-scripts/blob/master/build-uboot-bbb.sh
-#
-BEAGLEBONE_BLACK_BINARIES="beaglebone-black-integration-debian-emmc-2018.07.004.tar"
+#    https://github.com/mendersoftware/mender-convert-integration-scripts/blob/master/build-uboot-bbb.sh
+
+BEAGLEBONE_BLACK_CONFIG="beaglebone_black_debian_emmc"
 source configs/beaglebone_black_base_config
 MENDER_STORAGE_TOTAL_SIZE_MB="3648"
 MENDER_DEVICE_TYPE="beaglebone-emmc"

--- a/configs/beaglebone_black_debian_sdcard_config
+++ b/configs/beaglebone_black_debian_sdcard_config
@@ -1,8 +1,4 @@
-# Binaries generated with the following script:
-#
-#    https://github.com/drewmoseley/mender-convert-integration-scripts/blob/master/build-uboot-bbb.sh
-#
-BEAGLEBONE_BLACK_BINARIES="beaglebone-black-integration-debian-sdcard-2018.07.004.tar"
+BEAGLEBONE_BLACK_CONFIG="beaglebone_black_debian_sdcard"
 source configs/beaglebone_black_base_config
 MENDER_DEVICE_TYPE="beaglebone-sdcard"
 MENDER_STORAGE_DEVICE="/dev/mmcblk0p"

--- a/configs/raspberrypi0w_config
+++ b/configs/raspberrypi0w_config
@@ -1,7 +1,4 @@
-# Binaries generated with the following script:
-#
-#    https://github.com/drewmoseley/mender-convert-integration-scripts/blob/master/build-uboot-rpi.sh
-RASPBERRYPI_BINARIES="raspberrypi0w-integration-2019.01.tar.gz"
+RASPBERRYPI_CONFIG="raspberrypi0w"
 RASPBERRYPI_KERNEL_IMAGE="kernel.img"
 MENDER_KERNEL_IMAGETYPE=zImage
 

--- a/configs/raspberrypi3_config
+++ b/configs/raspberrypi3_config
@@ -1,7 +1,4 @@
-# Binaries generated with the following script:
-#
-#    https://github.com/drewmoseley/mender-convert-integration-scripts/blob/master/build-uboot-rpi.shraspberrypi-integration-scripts.tar.gz
-RASPBERRYPI_BINARIES="raspberrypi3-integration-2019.01.tar.gz"
+RASPBERRYPI_CONFIG="raspberrypi3"
 RASPBERRYPI_KERNEL_IMAGE="kernel7.img"
 MENDER_KERNEL_IMAGETYPE="zImage"
 

--- a/configs/raspberrypi4_config
+++ b/configs/raspberrypi4_config
@@ -1,7 +1,4 @@
-# Binaries generated with the following script:
-#
-#    https://github.com/drewmoseley/mender-convert-integration-scripts/blob/master/build-uboot-rpi.shraspberrypi-integration-scripts.tar.gz
-RASPBERRYPI_BINARIES="raspberrypi4-integration-2019.01.tar.gz"
+RASPBERRYPI_CONFIG="raspberrypi4"
 RASPBERRYPI_KERNEL_IMAGE="kernel7l.img"
 MENDER_KERNEL_IMAGETYPE="zImage"
 

--- a/configs/raspberrypi_config
+++ b/configs/raspberrypi_config
@@ -1,3 +1,6 @@
+# Binaries generated with the following script:
+#    https://github.com/mendersoftware/mender-convert-integration-scripts/blob/master/build-uboot-rpi.sh
+
 # Raspberry Pi does not support GRUB bootloader integration, fallback to U-boot.
 MENDER_GRUB_EFI_INTEGRATION=n
 
@@ -7,7 +10,8 @@ MENDER_COPY_BOOT_GAP=n
 # 4MB alignment
 MENDER_PARTITION_ALIGNMENT="4194304"
 
-RASPBERRYPI_BINARIES_URL="${MENDER_STORAGE_URL}/mender-convert/raspberrypi/${RASPBERRYPI_BINARIES}"
+RASPBERRYPI_BINARIES="${RASPBERRYPI_CONFIG}-2019.01.tar.gz"
+RASPBERRYPI_BINARIES_URL="${MENDER_STORAGE_URL}/mender-convert/uboot/raspberrypi/${RASPBERRYPI_BINARIES}"
 
 function platform_modify() {
   mkdir -p work/rpi/binaries

--- a/configs/rockpro64_config
+++ b/configs/rockpro64_config
@@ -1,10 +1,14 @@
+# Binaries generated with the following script:
+#    https://d1b0l86ne08fsf.cloudfront.net/mender-convert/uboot/rockpro64/integration-scripts.tar.gz
+
 # ROCKPro64 do not support GRUB bootloader integration, fallback to U-boot.
 MENDER_GRUB_EFI_INTEGRATION=n
 
 # We will write a modified bootloader
 MENDER_COPY_BOOT_GAP=n
 
-ROCKPRO64_BINARIES_URL="${MENDER_STORAGE_URL}/mender-convert/armbian/rockpro64/${ROCKPRO64_BINARIES}"
+ROCKPRO64_BINARIES="${ROCKPRO64_CONFIG}-2017.09.tar.gz"
+ROCKPRO64_BINARIES_URL="${MENDER_STORAGE_URL}/mender-convert/uboot/rockpro64/${ROCKPRO64_BINARIES}"
 
 function platform_modify() {
   mkdir -p work/rockpro64

--- a/configs/rockpro64_emmc_config
+++ b/configs/rockpro64_emmc_config
@@ -1,8 +1,4 @@
+ROCKPRO64_CONFIG="rockpro64_emmc"
 MENDER_STORAGE_DEVICE=/dev/mmcblk1p
-
-# Binaries generated with the following script:
-#
-#    https://d1b0l86ne08fsf.cloudfront.net/mender-convert/armbian/rockpro64/integration-scripts.tar.gz
-ROCKPRO64_BINARIES="emmc-boot-integration-2017.09.tar.gz"
 
 source configs/rockpro64_config

--- a/configs/rockpro64_sd_config
+++ b/configs/rockpro64_sd_config
@@ -1,6 +1,3 @@
-# Binaries generated with the following script:
-#
-#    https://d1b0l86ne08fsf.cloudfront.net/mender-convert/armbian/rockpro64/integration-scripts.tar.gz
-ROCKPRO64_BINARIES="sd-boot-integration-2017.09.tar.gz"
+ROCKPRO64_CONFIG="rockpro64_sd"
 
 source configs/rockpro64_config


### PR DESCRIPTION
See also https://github.com/mendersoftware/mender-convert-integration-scripts/pull/3

The S3 path now follows the pattern:
`/mender/mender-convert/uboot/<dev-family>/<dev-config>-<uboot-ver>.tar`

For RPi and BBB these are automatically published form the CI Pipeline
of repo mender-convert-integration-scripts while for RockPro64 they have
been manually moved (as we expect this to be a one time integration).

Reworked a bit also the *_BINARIES variable so that we can keep the
u-boot version in the base config files and let the childs only define
the a config name.

Changelog: None

Signed-off-by: Lluis Campos <lluis.campos@northern.tech>