### PR TITLE
Fix Rasbperry Pi device type

### DIFF
--- a/configs/raspberrypi_config
+++ b/configs/raspberrypi_config
@@ -1,6 +1,9 @@
 # Binaries generated with the following script:
 #    https://github.com/mendersoftware/mender-convert-integration-scripts/blob/master/build-uboot-rpi.sh
 
+# Fix device type to avoid hostname as a source
+MENDER_DEVICE_TYPE="raspberrypi"
+
 # Raspberry Pi does not support GRUB bootloader integration, fallback to U-boot.
 MENDER_GRUB_EFI_INTEGRATION=n
 


### PR DESCRIPTION
I've built my custom Raspbian image using [pi-gen](https://github.com/RPi-Distro/pi-gen) project. By default, it generates random hostname but i am using other values too and it should not matter when it comes to determining the device type.

I found that device type of the generated image (and artifact) is taken from `/etc/hostname`. Since i do not understand what's the rationale for such source of default value for device type my proposition is to fix the device type in the config at least for Raspberry family which would work exactly the same as for oryginal Raspbian images.