### PR TITLE
Require a 8GB SD card for the converted Raspbian

### DIFF
--- a/configs/images/raspberrypi3_raspbian_config
+++ b/configs/images/raspberrypi3_raspbian_config
@@ -1,8 +1,8 @@
 # Real life SD cards typically have less than they advertise. First off, they
 # often use a base of 1000 instead of 1024, and even then they are often smaller
-# than advertised. The number below is based on a conservative target of 3.9GB
+# than advertised. The number below is based on a conservative target of 7.9GB
 # (that's mathematical GB, base 1000), converted to MiB, rounding down.
-MENDER_STORAGE_TOTAL_SIZE_MB=3719
+MENDER_STORAGE_TOTAL_SIZE_MB=7534
 
 # Use all there is, which gets us almost, but not quite, to 500MiB free space
 # (about 480MiB at the time of writing).


### PR DESCRIPTION
The previous 4GB size gave an aprox 1.5GB rootfs, which was not enough
to run a full `apt-get update && apt-upgrade` after flashing.

Changelog: None

Signed-off-by: Lluis Campos <lluis.campos@northern.tech>