### PR TITLE
Fix DTB boot issue and switch back to GRUB 2.04

### DIFF
--- a/configs/mender_grub_config
+++ b/configs/mender_grub_config
@@ -32,4 +32,4 @@ MENDER_GRUB_KERNEL_IMAGETYPE=""
 # if was not possible to auto-detect
 MENDER_GRUB_INITRD_IMAGETYPE=""
 
-MENDER_GRUB_BINARY_STORAGE_URL="${MENDER_STORAGE_URL}/mender-convert/grub-efi/2.04"
+MENDER_GRUB_BINARY_STORAGE_URL="${MENDER_STORAGE_URL}/mender-convert/grub-efi/2.02"

--- a/mender-convert-modify
+++ b/mender-convert-modify
@@ -164,6 +164,18 @@ EOF
 
   run_and_log_cmd "sudo mkdir -p work/boot/EFI/BOOT"
   run_and_log_cmd "sudo cp work/${efi_name} -P work/boot/EFI/BOOT/${efi_target_name}"
+
+  # Copy dtb directory to the boot partition for use by the bootloader.
+  if [ -d work/rootfs/boot/dtbs ]; then
+    # Look for the first directory that has dtb files. First check the base
+    # folder, then any subfolders in versioned order.
+    for candidate in work/rootfs/boot/dtbs $(find work/rootfs/boot/dtbs/ -maxdepth 1 -type d | sort -V -r); do
+      if [ $(find $candidate -maxdepth 1 -name '*.dtb' | wc -l) -gt 0 ]; then
+        run_and_log_cmd "cp -r $candidate work/boot/dtb"
+        break
+      fi
+    done
+  fi
 fi
 
 run_and_log_cmd "sudo mkdir -p work/rootfs/data/mender"


### PR DESCRIPTION
```
commit 8d6902707187a8a683947d9c37457bfa7ba994d7
Author: Kristian Amlie <kristian.amlie@northern.tech>
Date:   Thu Feb 6 11:01:57 2020

    Switch back to GRUB 2.02.
    
    2.04 does not work on Beaglebone Black.
    Ticket: https://tracker.mender.io/browse/MEN-2404
    
    Changelog: None
    
    Signed-off-by: Kristian Amlie <kristian.amlie@northern.tech>

commit c321684a03764468877aee6b92b49835a6550990
Author: Kristian Amlie <kristian.amlie@northern.tech>
Date:   Tue Jan 28 15:33:39 2020

    Make sure that DTB files are included on boot partition.
    
    This is important so that the bootloader (U-Boot) can use the DTB
    files when chainloading GRUB via UEFI. The logic for doing this is
    already present in `distro_bootcmd`, but because we were not placing
    the DTB files in the correct folder, this part was skipped.
    
    Changelog: Fix certain kernels hanging on boot. In particular, recent
    versions of Debian for Beaglebone was affected, but several other
    boards using UEFI may also have been affected.
    
    Signed-off-by: Kristian Amlie <kristian.amlie@northern.tech>
```