### PR TITLE
[pipeline] Set docker:dind image to a fixed version

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -31,7 +31,7 @@ stages:
 build:
   stage: build
   services:
-    - docker:dind
+    - docker:19.03.5-dind
   script:
     - IMAGE_NAME=$DOCKER_REPOSITORY:pr ./docker-build --build-arg MENDER_ARTIFACT_VERSION=${MENDER_ARTIFACT_VERSION}
     - docker save $DOCKER_REPOSITORY:pr > image.tar


### PR DESCRIPTION
So that we can workaround a temporary issue with latest docker:dind

See MEN-3200

See https://gitlab.com/gitlab-com/support-forum/issues/5194#note_288438588

Changelog: None

Signed-off-by: Lluis Campos <lluis.campos@northern.tech>