### PR TITLE
Added hooks to mender-convert

### DIFF
--- a/mender-convert-modify
+++ b/mender-convert-modify
@@ -19,10 +19,12 @@
 function platform_modify() {
   true
 }
+PLATFORM_MODIFY_HOOKS=(platform_modify)
 
 function user_local_modify() {
   true
 }
+USER_LOCAL_MODIFY_HOOKS=(user_local_modify)
 
 function trap_exit() {
   echo "mender-convert-modify has finished. Cleaning up..."
@@ -233,10 +235,16 @@ ${MENDER_STORAGE_DEVICE_BASE}${MENDER_DATA_PART_NUMBER}   /data          auto   
 EOF"
 
 log_info "Performing platform specific modifications (if any)"
-platform_modify
+for hook in "${PLATFORM_MODIFY_HOOKS[@]}"; do
+  log_info "Running hook: $hook"
+  eval $hook
+done
 
 log_info "Performing user/local specific modifications (if any)"
-user_local_modify
+for hook in "${USER_LOCAL_MODIFY_HOOKS[@]}"; do
+  log_info "Running hook: $hook"
+  eval $hook
+done
 
 for overlay in "${overlays[@]}"; do
   log_info "Applying rootfs overlay: ${overlay}"

--- a/mender-convert-package
+++ b/mender-convert-package
@@ -19,6 +19,7 @@
 function platform_package() {
   true
 }
+PLATFORM_PACKAGE_HOOKS=(platform_package)
 
 function trap_exit() {
   echo "mender-convert-package has finished. Cleaning up..."
@@ -244,7 +245,10 @@ disk_write_at_offset "${output_dir}/rootfs.img" "${img_path}" "${rootfsb_start}"
 disk_write_at_offset "${output_dir}/data.img" "${img_path}" "${data_start}"
 
 log_info "Performing platform specific package operations (if any)"
-platform_package
+for hook in "${PLATFORM_PACKAGE_HOOKS[@]}"; do
+  log_info "Running hook: $hook"
+  eval $hook
+done
 
 # Create bmap index
 if [ "${MENDER_USE_BMAP}" == "y" ]; then


### PR DESCRIPTION
This extends the current functionality of the platform_<stage> function
functionality into using hooks, so that each modification step can be called
from multiple configuration files.

The valid hooks are:

* PLATFORM_MODIFY_HOOKS
* PLATFORM_PACKAGE_HOOKS
* USER_LOCAL_MODIFY_HOOKS

and can be appended to as a regular bash array.

Changelog: Commit

Signed-off-by: Ole Petter <ole.orhagen@northern.tech>