### PR TITLE
COMFILE PI support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -42,6 +42,8 @@ RUN apt-get update && apt-get install -y \
     udev \
 # to create bmap index file (MENDER_USE_BMAP)
     bmap-tools \
+# to regenerate the U-Boot boot.scr on platforms that need customization
+    u-boot-tools \
 # needed to run pxz
     libgomp1
 

--- a/configs/comfile_pi_config
+++ b/configs/comfile_pi_config
@@ -1,0 +1,26 @@
+MENDER_STORAGE_TOTAL_SIZE_MB="14000"
+# default: MENDER_DATA_PART_SIZE_MB="128"
+# default: MENDER_BOOT_PART_SIZE_MB="40"
+
+function enable_lcd_backlight_comfile_pi() {
+    cat <<- 'EOF' > work/boot/boot.cmd
+#
+# Customized boot script for COMFILE PI.
+#
+
+# This line enables the backlight on the display of the COMFILE PI
+gpio set 34
+
+fdt addr ${fdt_addr} && fdt get value bootargs /chosen bootargs
+run mender_setup
+mmc dev ${mender_uboot_dev}
+load ${mender_uboot_root} ${kernel_addr_r} /boot/zImage
+bootz ${kernel_addr_r} - ${fdt_addr}
+run mender_try_to_recover
+EOF
+    mkimage -C none -A arm -T script -d work/boot/boot.cmd work/boot/boot.scr
+    rm -f work/boot/boot.cmd
+}
+PLATFORM_MODIFY_HOOKS+=(enable_lcd_backlight_comfile_pi)
+
+source configs/raspberrypi3_config

--- a/requirements-deb.txt
+++ b/requirements-deb.txt
@@ -1,1 +1,1 @@
-binutils xz-utils file rsync parted e2fsprogs xfsprogs pigz dosfstools wget git make bmap-tools
+binutils xz-utils file rsync parted e2fsprogs xfsprogs pigz dosfstools wget git make bmap-tools u-boot-tools


### PR DESCRIPTION
In the case of the COMFILE PI which is a customized system
with a RPI Compute Module, we need to add some gpio commands
into the boot.scr.

Signed-off-by: Drew Moseley <drew.moseley@northern.tech>