### PR TITLE
Rearrange the AWS credential logic to support project wide variables.

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -52,6 +52,8 @@ build:
     - convert_raspbian
   timeout: 2h
   before_script:
+    - export AWS_ACCESS_KEY_ID=$TMP_STORAGE_AWS_ACCESS_KEY_ID
+    - export AWS_SECRET_ACCESS_KEY=$TMP_STORAGE_AWS_SECRET_ACCESS_KEY
     # Install dependencies
     - apt update
     - apt install -qyy bash wget git util-linux mtools python3 python3-pip
@@ -118,6 +120,9 @@ convert_raspbian:
   dependencies:
     - build
   before_script:
+    - export AWS_ACCESS_KEY_ID=$TMP_STORAGE_AWS_ACCESS_KEY_ID
+    - export AWS_SECRET_ACCESS_KEY=$TMP_STORAGE_AWS_SECRET_ACCESS_KEY
+
     - apt update && apt install -yy bash wget unzip awscli
 
     - export IMAGE_NAME=$DOCKER_REPOSITORY:pr
@@ -143,12 +148,16 @@ publish:s3:
   stage: publish
   image: debian:buster
   before_script:
+    - export PUBLISH_AWS_ACCESS_KEY_ID=$AWS_ACCESS_KEY_ID
+    - export PUBLISH_AWS_SECRET_ACCESS_KEY=$AWS_SECRET_ACCESS_KEY
+    - export AWS_ACCESS_KEY_ID=$TMP_STORAGE_AWS_ACCESS_KEY_ID
+    - export AWS_SECRET_ACCESS_KEY=$TMP_STORAGE_AWS_SECRET_ACCESS_KEY
     - apt update && apt install -yyq awscli
     # Fetch artifacts from temporary S3 bucket
     - aws s3 cp s3://mender-gitlab-tmp-storage/$CI_PROJECT_NAME/$CI_PIPELINE_ID/deploy.tar.gz deploy.tar.gz
     - tar xzf deploy.tar.gz
   script:
-    # Prepare high privilege S3 keys (the base keys are for the tmp storage only)
+    # Prepare high privilege S3 keys (the TMP_STORAGE keys are for the tmp storage only)
     - export AWS_ACCESS_KEY_ID=$PUBLISH_AWS_ACCESS_KEY_ID
     - export AWS_SECRET_ACCESS_KEY=$PUBLISH_AWS_SECRET_ACCESS_KEY
     - echo "Publishing ${RASPBIAN_NAME}-mender-${MENDER_CLIENT_VERSION}.img.xz version to S3"


### PR DESCRIPTION
The publishing variables have no prefix, and the tmp storage ones have
a TMP_STORAGE prefix, so adapt to that.

Changelog: None

Signed-off-by: Kristian Amlie <kristian.amlie@northern.tech>