### PR TITLE
MEN-2151: Add support for GPT partition tables

### DIFF
--- a/configs/mender_convert_config
+++ b/configs/mender_convert_config
@@ -65,6 +65,11 @@ MENDER_DATA_PART_GROWFS=y
 # input disk image
 MENDER_DEVICE_TYPE=""
 
+# The partition scheme to use for the converted image.
+# To override set this to "gpt" or "dos" (the scheme names used by fdisk and partx).
+# By default mender-convert will use the partition scheme from the input image.
+MENDER_PARTITION_SCHEME=""
+
 # Total size of the physical storage medium that mender partitioned images
 # will be written to, expressed in MiB. The size of rootfs partition will be
 # calculated automatically by subtracting the sizes of boot

--- a/mender-convert-package
+++ b/mender-convert-package
@@ -223,9 +223,26 @@ rootfsb_end=$(( ${rootfsb_start} + ${rootfs_part_sectors} - 1 ))
 data_start=$(disk_align_sectors ${rootfsb_end} ${MENDER_PARTITION_ALIGNMENT} )
 data_end=$(( ${data_start} + ${data_part_sectors} - 1 ))
 
-# Create partition table. TODO: GPT support
-run_and_log_cmd "${PARTED} -s ${img_path} mklabel msdos"
-run_and_log_cmd "${PARTED} -s ${img_path} unit s mkpart primary fat32 ${boot_part_start} ${boot_part_end}"
+if [ -n "${MENDER_PARTITION_SCHEME}" ]; then
+  # Force partition scheme to the one from configs
+  partition_scheme="${MENDER_PARTITION_SCHEME}"
+  log_info "Forcing partition scheme defined by MENDER_PARTITION_SCHEME to: ${partition_scheme}"
+else
+  # By default use the partition scheme from the input image
+  partition_scheme=$(disk_get_part_value ${disk_image} 1 SCHEME)
+  log_info "Using input diskimage partition scheme (${partition_scheme})"
+fi
+
+# Create partition table.
+if [ "${partition_scheme}" == "gpt" ]; then
+  log_info "Writing GPT partition table"
+  run_and_log_cmd "${PARTED} -s ${img_path} mklabel gpt"
+  run_and_log_cmd "${PARTED} -s ${img_path} unit s mkpart ESP fat32 ${boot_part_start} ${boot_part_end}"
+else
+  log_info "Writing DOS (MBR) partition table"
+  run_and_log_cmd "${PARTED} -s ${img_path} mklabel msdos"
+  run_and_log_cmd "${PARTED} -s ${img_path} unit s mkpart primary fat32 ${boot_part_start} ${boot_part_end}"
+fi
 run_and_log_cmd "${PARTED} -s ${img_path} set 1 boot on"
 run_and_log_cmd "${PARTED} -s ${img_path} -- unit s mkpart primary ext2 ${rootfsa_start} ${rootfsa_end}"
 run_and_log_cmd "${PARTED} -s ${img_path} -- unit s mkpart primary ext2 ${rootfsb_start} ${rootfsb_end}"

--- a/mender-convert-package
+++ b/mender-convert-package
@@ -256,9 +256,13 @@ if [ "${MENDER_COPY_BOOT_GAP}" == "y" ]; then
 fi
 
 # Burn Partitions
+log_info "Writing boot partition image"
 disk_write_at_offset "${boot_part}" "${img_path}" "${boot_part_start}"
+log_info "Writing rootfsa partition image"
 disk_write_at_offset "${output_dir}/rootfs.img" "${img_path}" "${rootfsa_start}"
+log_info "Writing rootfsb partition image"
 disk_write_at_offset "${output_dir}/rootfs.img" "${img_path}" "${rootfsb_start}"
+log_info "Writing data partition image"
 disk_write_at_offset "${output_dir}/data.img" "${img_path}" "${data_start}"
 
 log_info "Performing platform specific package operations (if any)"

--- a/modules/disk.sh
+++ b/modules/disk.sh
@@ -96,7 +96,7 @@ disk_align_sectors() {
 # $2 - destination file
 # $3 - offset in number of 512 sectors
 disk_write_at_offset() {
-  run_and_log_cmd "dd if=${1} of=${2} seek=${3} conv=sparse status=none"
+  run_and_log_cmd "dd if=${1} of=${2} seek=${3} conv=sparse,notrunc status=none"
 }
 
 # Create file system image from directory content


### PR DESCRIPTION
Partition scheme can be forced by setting MENDER_PARTITION_SCHEME="gpt" or MENDER_PARTITION_SCHEME="dos", otherwise it will use the scheme from the input image.

Changelog: Add support for GPT partition tables

Signed-off-by: Nate Baker <bakern@gmail.com>