### PR TITLE
Fix incorrect use of partition number

### DIFF
--- a/mender-convert-extract
+++ b/mender-convert-extract
@@ -65,7 +65,8 @@ if [ ! -f ${MKFS_VFAT} ]; then
   MKFS_VFAT="/sbin/mkfs.vfat"
 fi
 
-declare -i nr_of_parts=$(disk_get_nr_of_parts ${disk_image})
+declare -a part_nrs=($(disk_get_part_nums ${disk_image}))
+declare -i nr_of_parts=${#part_nrs[@]}
 
 log_info "Validating disk image"
 
@@ -76,7 +77,7 @@ fi
 log_info "Disk parsed successfully"
 log_info "NUMBER OF PARTS: ${nr_of_parts} TYPE: $(disk_get_part_value ${disk_image} 1 SCHEME)"
 
-for ((n=1;n<=${nr_of_parts};n++)); do
+for n in ${part_nrs[*]} ; do
   part_dst_file="work/part-${n}.fs"
 
   if [ "$(disk_get_part_value ${disk_image} ${n} TYPE)" == "0x8e" ]; then

--- a/modules/disk.sh
+++ b/modules/disk.sh
@@ -40,15 +40,19 @@ disk_get_part_value() {
   echo "$(partx -o ${3} -g -r --nr ${2} ${1})"
 }
 
-# Prints number of partitions found in disk image
+# Prints the partition numbers of all the partitions
 #
 # Example usage:
 #
-#     nr_of_parts=$(disk_get_nr_of_parts ${disk_image_path})
+#     part_nums=$(disk_get_part_nums ${disk_image_path})
 #
 #  $1 - path to disk image
-disk_get_nr_of_parts() {
-  echo "$(partx -l ${1} | wc -l)"
+disk_get_part_nums() {
+  partx --show $1 | tail -n +2 |
+    while read line
+    do
+      echo $line | awk '{printf "%d\n", $1}'
+    done
 }
 
 # Extract a file system image from a disk image


### PR DESCRIPTION
The current code enumerates the partitions and uses the index of this
enumeration to query partition parameters rather than the actual
partition number that is reported and expected by partx. This might not
work in certain cases.

Example:
/dev/sda1
/dev/sda2
/dev/sda5

The partition number of the last partition is 5 but current code will
use 3. This PR fixes this so that the actual number reported by partx is
used for all operations rather than the enumerated index.