### PR TITLE
Report which error occured before exiting

### DIFF
--- a/mender-convert
+++ b/mender-convert
@@ -44,6 +44,12 @@ function show_version() {
 }
 
 function trap_exit() {
+  EXIT_CODE=$?
+  if [[ ${EXIT_CODE} -ne 0 && ${EXIT_CODE} -ne ${FATAL_EXIT_CODE} ]]; then
+    log_error "mender-convert failed"
+    tac work/convert.log | sed '/DEBUG/q' | tac | sed 's/Running/When running/'
+    log_error "mender-convert exit code: ${EXIT_CODE}"
+  fi
   sudo rm -rf work
 }
 

--- a/mender-convert-extract
+++ b/mender-convert-extract
@@ -14,6 +14,17 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
+function trap_exit() {
+  echo "mender-convert-extract has finished. Cleaning up..."
+}
+
+function trap_term() {
+  true
+}
+
+trap trap_term INT TERM
+trap trap_exit EXIT
+
 echo "Running $(basename $0): $@"
 
 source modules/bootstrap.sh

--- a/modules/log.sh
+++ b/modules/log.sh
@@ -68,8 +68,9 @@ function log_error {
 }
 
 # Log the given message at FATAL level.
+FATAL_EXIT_CODE=90
 function log_fatal {
   local -r message="$1"
   log "${IRED}FATAL${NC}" "$message"
-  exit 1
+  exit ${FATAL_EXIT_CODE}
 }

--- a/modules/run.sh
+++ b/modules/run.sh
@@ -19,10 +19,15 @@
 #  $1 - command to run
 function run_and_log_cmd() {
   local -r cmd="${1}"
-
-  log_debug "Running: \n\r\n\r\t ${cmd}"
-  log_debug "Run result: \n\r"
-
-  result=$(eval ${cmd})
-  log_debug "${result}"
+  local -r position="(${BASH_SOURCE[1]}:${BASH_LINENO[0]}): ${FUNCNAME[0]:+${FUNCNAME[0]}(): }"
+  local exit_code=0
+  output="$({ eval ${cmd}; } 2>&1)" || exit_code=$?
+  local log_msg="Running: ${position} \n\r\n\r\t${cmd}"
+  if [[ "${output}" != "" ]]; then
+    log_msg="${log_msg}\n\t${output}\n"
+  fi
+  log_debug "${log_msg}"
+  if [[ ${exit_code} -ne 0 ]]; then
+    exit ${exit_code}
+  fi
 }


### PR DESCRIPTION
This adds more accurate descriptions of what error actually occured during
script execution, as compared to previously, where it would silently fail, and
it could be hard to figure out exactly where the error occured.

Now, upon an error, the script will always output these lines (or similar) at the end:

```bash
2020-04-23 13:03:35 [ERROR] [mender-convert-modify] mender-convert-modify failed
2020-04-23 13:03:35 [ERROR] [mender-convert] mender-convert failed with error code: 1
From command:
2020-04-23 13:03:35 [DEBUG] [mender-convert-modify] Running: (./mender-convert-modify:214): run_and_log_cmd():

	 sudo install -m 0444 work/device_type work/rootfs/data/mender/
Exit status: [1]
Collected output:
install: cannot stat 'work/device_type': No such file or directory
```

Which is a description of which part of the program failed. What the exit code
was, and the last command entry in the debug log, and if any, the collected
output from the command is printed.

Changelog: Print improved error diagnostics before exiting on an error

Signed-off-by: Ole Petter <ole.orhagen@northern.tech>