### PR TITLE
Remove kernel_devicetree from EFI path.

### DIFF
--- a/mender-convert-modify
+++ b/mender-convert-modify
@@ -130,7 +130,6 @@ mender_kernel_root_base=${MENDER_STORAGE_DEVICE_BASE}
 mender_grub_storage_device=${MENDER_GRUB_STORAGE_DEVICE}
 kernel_imagetype=${kernel_imagetype}
 initrd_imagetype=${initrd_imagetype}
-kernel_devicetree=${MENDER_DTB_NAME}
 EOF
 
   if [ -n "${MENDER_GRUB_KERNEL_BOOT_ARGS}" ]; then


### PR DESCRIPTION
This information is not used when loading via UEFI, instead it is
queried directly from the UEFI provider.

Changelog: Commit

Signed-off-by: Kristian Amlie <kristian.amlie@northern.tech>