### PR TITLE
MEN-3527: Fix regressions introduced during refactoring

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ rootfs_overlay_demo/*
 mender_local_config
 *.xml
 *.html
+convert.log

--- a/mender-convert
+++ b/mender-convert
@@ -29,8 +29,6 @@ declare -a overlays=()        # [Dummy] Needed in parse_cli_options, not here
 declare -a configs=()        # [Dummy] Needed in parse_cli_options, not here
 ###############################################################################
 
-MENDER_CONVERT_VERSION=$(git describe --tags --dirty --exact-match 2>/dev/null || git rev-parse --short HEAD)
-
 function show_help() {
   cat << EOF
 mender-convert

--- a/mender-convert
+++ b/mender-convert
@@ -29,7 +29,9 @@ declare compression_type=""   # Detected input file compression, also applied to
 declare ocfile="./work/override_compression_config"
 declare disk_image=""         # Needed in parse_cli_options, and is passed to decompress_image()
 declare -a overlays=()        # [Dummy] Needed in parse_cli_options, not here
-declare -a configs=()        # [Dummy] Needed in parse_cli_options, not here
+declare -a configs=()         # [Dummy] Needed in parse_cli_options, not here
+MENDER_ARTIFACT_NAME="${MENDER_ARTIFACT_NAME:-}"     # Required env variable
+MENDER_CONVERT_VERSION="${MENDER_CONVERT_VERSION:-}" # Required env variable
 ###############################################################################
 
 function show_help() {

--- a/mender-convert
+++ b/mender-convert
@@ -18,6 +18,9 @@ source modules/bootstrap.sh
 source modules/cliparser.sh
 source modules/decompressinput.sh
 
+mkdir -p work
+touch work/convert.log
+
 ###############################################################################
 #                Declaration of important variables for this file             #
 ###############################################################################
@@ -111,8 +114,6 @@ if [ -z "${MENDER_ARTIFACT_NAME}" ]; then
   echo -e "\tMENDER_ARTIFACT_NAME=\"release-1\" ./mender-convert"
   exit 1
 fi
-mkdir -p work
-touch work/convert.log
 
 parse_cli_options "$@"
 

--- a/modules/decompressinput.sh
+++ b/modules/decompressinput.sh
@@ -81,7 +81,7 @@ function decompress_image () {
       xzcat "${input_image}" > "${disk_image}"
       ;;
     * )
-      log_fatal "Unsupported input image type: ${input_image}"
+      log_fatal "Unsupported input image format: ${input_image}. We support: '.img', '.gz', '.zip', '.xz'."
       ;;
   esac
   echo "${disk_image}"


### PR DESCRIPTION
This fixes misc minor regressions introduced during my refactoring

* Declare the required env variables to empty string
* Create the work-dir before running any conversion commands
* Remove MENDER_CONVERT_VERSION definition from mender-convert
* Improve the error message on unsupported image types

Also, some of these only shows up when not running this in the docker container, which we are not testing at all.

I guess we should start testing this also. Question is then: What exactly? Just one of the boards as a smoke test? I guess all of them is a little over the top.