### PR TITLE
Misc changes for Yocto

### DIFF
--- a/configs/generic_x86-64_hdd_config
+++ b/configs/generic_x86-64_hdd_config
@@ -38,3 +38,14 @@ MENDER_STORAGE_TOTAL_SIZE_MB=16000
 
 # Nothing to copy
 MENDER_COPY_BOOT_GAP="n"
+
+function platform_modify() {
+    #
+    # Make sure /lib64 exists since the Mender binary requires it.
+    # Some systems put everything under /lib (ie Yocto) and a simple
+    # symlink is enough to find everything Mender needs.
+    #
+    if [ ! -e work/rootfs/lib64 ]; then
+        run_and_log_cmd "ln -s /lib work/rootfs/lib64"
+    fi
+}

--- a/modules/decompressinput.sh
+++ b/modules/decompressinput.sh
@@ -28,7 +28,7 @@ function compression_type () {
   fi
   local -r disk_image="${1}"
   case "${disk_image}" in
-    *.img | *.sdimg)
+    *.img | *.sdimg | *.wic | *.rpi-sdimg)
       echo "none"
       ;;
     *.gz)

--- a/modules/probe.sh
+++ b/modules/probe.sh
@@ -23,6 +23,9 @@ probe_arch() {
   # to busybox
   file_info=""
   for location in bin/ls usr/bin/ls; do
+    if [ -L work/rootfs/${location} ]; then
+        location=$(readlink work/rootfs/${location})
+    fi
     if [ -e work/rootfs/${location} ]; then
       file_info=$(file -b --dereference work/rootfs/${location})
       break


### PR DESCRIPTION
I am attempting to use mender-convert on a pre-built Yocto image for intel.  I needed these changes as a start to support the existing intel-corei7-64 builds.