### PR TITLE
2.0.x: Switch Docker container from 19.10 (EOL) to 20.04.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # Build pxz in separate image to avoid big image size
-FROM ubuntu:19.10 AS build
-RUN apt-get update && apt-get install -y \
+FROM ubuntu:20.04 AS build
+RUN apt-get update && env DEBIAN_FRONTEND=noninteractive apt-get install -y \
     build-essential \
     git \
     liblzma-dev
@@ -9,11 +9,11 @@ RUN apt-get update && apt-get install -y \
 RUN git clone https://github.com/jnovy/pxz.git /root/pxz
 RUN cd /root/pxz && make
 
-FROM ubuntu:19.10
+FROM ubuntu:20.04
 
 ARG MENDER_ARTIFACT_VERSION=3.3.0
 
-RUN apt-get update && apt-get install -y \
+RUN apt-get update && env DEBIAN_FRONTEND=noninteractive apt-get install -y \
 # For 'ar' command to unpack .deb
     binutils \
     xz-utils \


### PR DESCRIPTION
This also requires us to use noninteractive install environment
because of new timezone selection in tzdata package.

Changelog: Fix 404 download errors when trying to run `docker-build`.

Signed-off-by: Kristian Amlie <kristian.amlie@northern.tech>
(cherry picked from commit 2d92e2b5e72ab7ea3008a65f8b7d6531d67a02d0)