### PR TITLE
Update components for 2.4.0b1 Mender Product release.

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -5,8 +5,8 @@ variables:
   S3_BUCKET_NAME: mender-convert-images
   # These variables are present elsewhere in the repository too. Make sure to
   # search for and change them too.
-  MENDER_ARTIFACT_VERSION: master
-  MENDER_CLIENT_VERSION: master
+  MENDER_ARTIFACT_VERSION: 3.4.0b1
+  MENDER_CLIENT_VERSION: 2.3.0b1
   # Make sure to update the link in mender-docs to the new one when changing
   # this.
   RASPBIAN_URL: http://downloads.raspberrypi.org/raspbian_lite/images/raspbian_lite-2020-02-07/2020-02-05-raspbian-buster-lite.zip

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ RUN cd /root/pxz && make
 
 FROM ubuntu:20.04
 
-ARG MENDER_ARTIFACT_VERSION=3.2.1
+ARG MENDER_ARTIFACT_VERSION=3.4.0b1
 
 RUN apt-get update && env DEBIAN_FRONTEND=noninteractive apt-get install -y \
 # For 'ar' command to unpack .deb

--- a/configs/mender_convert_config
+++ b/configs/mender_convert_config
@@ -98,7 +98,7 @@ MENDER_PARTITION_ALIGNMENT="8388608"
 # Mender client version
 #
 # This is used to fetch the correct binaries
-MENDER_CLIENT_VERSION="master"
+MENDER_CLIENT_VERSION="2.3.0b1"
 
 # File storage, containing binary files, do not modify this unless you know
 # what you are doing.


### PR DESCRIPTION
Changelog: Upgrade mender-client to 2.3.0b1 and mender-artifact to
3.4.0b1.

Signed-off-by: Kristian Amlie <kristian.amlie@northern.tech>