### PR TITLE
Partition UUID support added for gpt/dos partition tables for deterministic booting

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,8 +21,9 @@ RUN apt-get update && env DEBIAN_FRONTEND=noninteractive apt-get install -y \
     file \
 # to copy files between rootfs directories
     rsync \
-# to generate partition table
+# to generate partition table and alter partitions
     parted \
+    gdisk \
 # mkfs.ext4 and family
     e2fsprogs \
 # mkfs.xfs and family
@@ -48,7 +49,9 @@ RUN apt-get update && env DEBIAN_FRONTEND=noninteractive apt-get install -y \
     libgomp1  \
 # zip and unzip archive
     zip  \
-    unzip
+    unzip \
+# manipulate binary and hex
+    xxd
 
 COPY --from=build /root/pxz/pxz /usr/bin/pxz
 

--- a/configs/mender_convert_config
+++ b/configs/mender_convert_config
@@ -122,6 +122,21 @@ MENDER_ROOTFS_PART_B_NUMBER="3"
 # Partition number of persistent data partition
 MENDER_DATA_PART_NUMBER="4"
 
+# Use partition uuids rather than device and partition numbers
+MENDER_ENABLE_PARTUUID="n"
+
+# Partition used as the boot partition.
+MENDER_BOOT_PART=""
+
+# Partition used as the first (A) rootfs partition.
+MENDER_ROOTFS_PART_A=""
+
+# Partition used as the first (B) rootfs partition.
+MENDER_ROOTFS_PART_B=""
+
+# Partition used as the persistent data partition.
+MENDER_DATA_PART=""
+
 # Basename of DTB that should be loaded by the bootloader.
 MENDER_DTB_NAME=kernel.dtb
 

--- a/mender-convert-modify
+++ b/mender-convert-modify
@@ -77,6 +77,12 @@ source modules/config.sh $(printf "%q " "${configs[@]}")
 boot_part=$(disk_boot_part)
 root_part=$(disk_root_part)
 
+# Sysfs device paths
+boot_part_device=$(disk_boot_part_device)
+data_part_device=$(disk_data_part_device)
+root_part_a_device=$(disk_root_part_a_device)
+root_part_b_device=$(disk_root_part_b_device)
+
 # Create mount points
 mkdir -p work/boot
 mkdir -p work/rootfs
@@ -126,11 +132,26 @@ if [ "${MENDER_GRUB_EFI_INTEGRATION}" == "y" ]; then
   cat <<- EOF > work/grub-mender-grubenv-${MENDER_GRUBENV_VERSION}/mender_grubenv_defines
 mender_rootfsa_part=${MENDER_ROOTFS_PART_A_NUMBER}
 mender_rootfsb_part=${MENDER_ROOTFS_PART_B_NUMBER}
-mender_kernel_root_base=${MENDER_STORAGE_DEVICE_BASE}
 mender_grub_storage_device=${MENDER_GRUB_STORAGE_DEVICE}
 kernel_imagetype=${kernel_imagetype}
 initrd_imagetype=${initrd_imagetype}
 EOF
+
+# For partuuid support grub.cfg expects dedicated variables to be added
+if [ "${MENDER_ENABLE_PARTUUID}" == "y" ]; then
+   rootfsa_partuuid=$(disk_get_partuuid_from_device "${root_part_a_device}")
+   rootfsb_partuuid=$(disk_get_partuuid_from_device "${root_part_b_device}")
+   log_info "Using root partition A partuuid in grubenv: $rootfsa_partuuid"
+   log_info "Using root partition B partuuid in grubenv: $rootfsb_partuuid"
+   cat <<- EOF >> work/grub-mender-grubenv-${MENDER_GRUBENV_VERSION}/mender_grubenv_defines
+mender_rootfsa_uuid=${rootfsa_partuuid}
+mender_rootfsb_uuid=${rootfsb_partuuid}
+EOF
+else
+  cat <<- EOF >> work/grub-mender-grubenv-${MENDER_GRUBENV_VERSION}/mender_grubenv_defines
+mender_kernel_root_base=${MENDER_STORAGE_DEVICE_BASE}
+EOF
+fi
 
   if [ -n "${MENDER_GRUB_KERNEL_BOOT_ARGS}" ]; then
     cat <<- EOF > work/grub-mender-grubenv-${MENDER_GRUBENV_VERSION}/11_bootargs_grub.cfg
@@ -185,10 +206,13 @@ fi
 run_and_log_cmd "sudo mkdir -p work/rootfs/data/mender"
 run_and_log_cmd "sudo ln -sf /data/mender work/rootfs/var/lib/mender"
 
+log_info "Using root device A in mender.conf: $root_part_a_device"
+log_info "Using root device B in mender.conf: $root_part_b_device"
+
 cat <<- EOF > work/mender.conf.data
 {
-  "RootfsPartA": "${MENDER_STORAGE_DEVICE_BASE}${MENDER_ROOTFS_PART_A_NUMBER}",
-  "RootfsPartB": "${MENDER_STORAGE_DEVICE_BASE}${MENDER_ROOTFS_PART_B_NUMBER}"
+  "RootfsPartA": "${root_part_a_device}",
+  "RootfsPartB": "${root_part_b_device}"
 }
 EOF
 
@@ -232,13 +256,17 @@ if [ "${MENDER_DATA_PART_GROWFS}" == "y" ]; then
   MENDER_DATA_PART_FSTAB_OPTS="${MENDER_DATA_PART_FSTAB_OPTS},x-systemd.growfs"
 fi
 
+
+log_info "Using boot partition device in fstab: $boot_part_device"
+log_info "Using data partition device in fstab: $data_part_device"
+
 sudo bash -c "cat <<- EOF > work/rootfs/etc/fstab
 # stock fstab - you probably want to override this with a machine specific one
 /dev/root            /                    auto       defaults              1  1
 proc                 /proc                proc       defaults              0  0
 
-${MENDER_STORAGE_DEVICE_BASE}${MENDER_BOOT_PART_NUMBER}   ${boot_part_mountpoint}          auto       defaults,sync    0  0
-${MENDER_STORAGE_DEVICE_BASE}${MENDER_DATA_PART_NUMBER}   /data          auto       ${MENDER_DATA_PART_FSTAB_OPTS}      0  0
+${boot_part_device}   ${boot_part_mountpoint}          auto       defaults,sync    0  0
+${data_part_device}   /data          auto       ${MENDER_DATA_PART_FSTAB_OPTS}      0  0
 EOF"
 
 log_info "Performing platform specific modifications (if any)"

--- a/mender-convert-package
+++ b/mender-convert-package
@@ -78,6 +78,12 @@ output_dir=work
 boot_part=$(disk_boot_part)
 root_part=$(disk_root_part)
 
+# Sysfs device paths
+boot_part_device=$(disk_boot_part_device)
+data_part_device=$(disk_data_part_device)
+root_part_a_device=$(disk_root_part_a_device)
+root_part_b_device=$(disk_root_part_b_device)
+
 # Final output
 mkdir -p deploy
 
@@ -249,6 +255,27 @@ run_and_log_cmd "${PARTED} -s ${img_path} -- unit s mkpart primary ext2 ${rootfs
 run_and_log_cmd "${PARTED} -s ${img_path} -- unit s mkpart primary ext2 ${data_start} ${data_end}"
 run_and_log_cmd "${PARTED} -s ${img_path} print"
 
+# Update partition uuids if required
+if [ "${MENDER_ENABLE_PARTUUID}" == "y" ]; then
+  boot_partuuid=$(disk_get_partuuid_from_device "${boot_part_device}")
+  rootfsa_partuuid=$(disk_get_partuuid_from_device "${root_part_a_device}")
+  rootfsb_partuuid=$(disk_get_partuuid_from_device "${root_part_b_device}")
+  data_partuuid=$(disk_get_partuuid_from_device "${data_part_device}")
+
+  if [ "${partition_scheme}" == "gpt" ]; then
+    log_info "Updating GPT partition uuids in image: '${img_path}'"
+    run_and_log_cmd "sgdisk -u ${MENDER_BOOT_PART_NUMBER}:${boot_partuuid} '${img_path}'"
+    run_and_log_cmd "sgdisk -u ${MENDER_ROOTFS_PART_A_NUMBER}:${rootfsa_partuuid} '${img_path}'"
+    run_and_log_cmd "sgdisk -u ${MENDER_ROOTFS_PART_B_NUMBER}:${rootfsb_partuuid} '${img_path}'"
+    run_and_log_cmd "sgdisk -u ${MENDER_DATA_PART_NUMBER}:${data_partuuid} '${img_path}'"
+  else
+    diskid=$(disk_get_partuuid_dos_diskid_from_device "${root_part_a_device}")
+    log_info "Updating MBR disk identifier for partition uuid support to: '0x${diskid}'"
+    run_and_log_cmd "xxd -r -p <<< '${diskid}' | LC_ALL=C rev | dd of='${img_path}' bs=1 seek=440 count=4 conv=notrunc"
+  fi
+
+fi
+
 # Write boot-gap
 if [ "${MENDER_COPY_BOOT_GAP}" == "y" ]; then
   log_info "Writing boot gap of size: ${boot_part_sectors} (sectors)"
@@ -324,16 +351,16 @@ fi
 distro_feature="${distro_feature} mender-convert"
 
 cat <<- EOF > deploy/${image_name}.cfg
-MENDER_BOOT_PART="${MENDER_STORAGE_DEVICE_BASE}${MENDER_BOOT_PART_NUMBER}"
-MENDER_ROOTFS_PART_A="${MENDER_STORAGE_DEVICE_BASE}${MENDER_ROOTFS_PART_A_NUMBER}"
-MENDER_ROOTFS_PART_B="${MENDER_STORAGE_DEVICE_BASE}${MENDER_ROOTFS_PART_B_NUMBER}"
+MENDER_BOOT_PART="${boot_part_device}"
+MENDER_ROOTFS_PART_A="${root_part_a_device}"
+MENDER_ROOTFS_PART_B="${root_part_b_device}"
+MENDER_DATA_PART="${data_part_device}"
 MENDER_BOOT_PART_MOUNT_LOCATION="${boot_part_mountpoint}"
 MENDER_BOOT_PART_SIZE_MB="$(disk_sectors_to_mb ${boot_part_sectors})"
 MENDER_DATA_PART_SIZE_MB="${MENDER_DATA_PART_SIZE_MB}"
 MENDER_DEVICE_TYPE="${device_type}"
 MENDER_PARTITIONING_OVERHEAD_KB="$(( (${overhead_sectors} * 512) / 1024 ))"
 MENDER_PARTITION_ALIGNMENT="${MENDER_PARTITION_ALIGNMENT}"
-MENDER_STORAGE_DEVICE_BASE="${MENDER_STORAGE_DEVICE_BASE}"
 MENDER_STORAGE_TOTAL_SIZE_MB="${MENDER_STORAGE_TOTAL_SIZE_MB}"
 MENDER_UBOOT_ENV_STORAGE_DEVICE_OFFSET="12582912"
 MENDER_ARTIFACT_NAME="${artifact_name}"
@@ -341,6 +368,14 @@ DISTRO_FEATURES="${distro_feature}"
 DEPLOY_DIR_IMAGE="${PWD}/deploy"
 MENDER_MACHINE="${device_type}"
 EOF
+
+
+# Outputting device base only relevant for some configurations
+if [ "${MENDER_ENABLE_PARTUUID}" != "y" ]; then
+    cat <<- EOF >> deploy/${image_name}.cfg
+MENDER_STORAGE_DEVICE_BASE="${MENDER_STORAGE_DEVICE_BASE}"
+EOF
+fi
 
 # Something that the tests expect to be defined (originally from Yocto)
 cat <<- EOF >> deploy/${image_name}.cfg

--- a/modules/config.sh
+++ b/modules/config.sh
@@ -20,3 +20,10 @@ for config in "${configs[@]}"; do
   log_info "Using configuration file: ${config}"
   source "${config}"
 done
+
+
+# Fine grained partition variables override device/number variables where applicable
+disk_override_partition_variable "MENDER_BOOT_PART_NUMBER" "${MENDER_BOOT_PART}"
+disk_override_partition_variable "MENDER_ROOTFS_PART_A_NUMBER" "${MENDER_ROOTFS_PART_A}"
+disk_override_partition_variable "MENDER_ROOTFS_PART_B_NUMBER" "${MENDER_ROOTFS_PART_B}"
+disk_override_partition_variable "MENDER_DATA_PART_NUMBER" "${MENDER_DATA_PART}"


### PR DESCRIPTION
Partition UUID support added for gpt and dos partition tables for deterministic booting
    
[Issue: MEN-3725](https://tracker.mender.io/browse/MEN-3725)    

The following new config variables have been added which closely mirror those used in meta-mender
to give fine grained controll over partition device paths. If partuuid support is enabled then
these partition variables must be used as format doesnt fit device/number variables scheme.
If partuuid support is disabled then partition variables are optional liek in meta-mender.
    

- MENDER_ENABLE_PARTUUID
- MENDER_BOOT_PART
- MENDER_ROOTFS_PART_A
- MENDER_ROOTFS_PART_B
- MENDER_DATA_PART


```
Example:
MENDER_BOOT_PART="/dev/disk/by-partuuid/26445670-f37c-408b-be2c-3ef419866620" #gpt
MENDER_BOOT_PART="/dev/disk/by-partuuid/26445670-01" #dos
MENDER_BOOT_PART="/dev/sda1" #partuuid support disabled
```
