### PR TITLE
RFC: mender-convert-modify: Check is selinux is configured in enforce …

### DIFF
--- a/mender-convert-modify
+++ b/mender-convert-modify
@@ -270,6 +270,19 @@ ${boot_part_device}   ${boot_part_mountpoint}          auto       defaults,sync 
 ${data_part_device}   /data          auto       ${MENDER_DATA_PART_FSTAB_OPTS}      0  0
 EOF"
 
+#
+# Make sure to re-label rootfs when selinux is in enforcing mode
+# e.g. CentOS8 after conversion cannot start login shell due selinux
+# inspired by: https://forums.centos.org/viewtopic.php?t=48714
+#
+if [ -f work/rootfs/etc/selinux/config ]; then
+  grep -r 'SELINUX=Enforcing' work/rootfs/etc/selinux/config || true
+  if [ $? -eq 0 ]; then
+    log_info "Selinux is in enforcing mode. Enable autorelabel"
+    touch work/rootfs/.autorelabel
+  fi
+fi
+
 log_info "Performing platform specific modifications (if any)"
 for hook in "${PLATFORM_MODIFY_HOOKS[@]}"; do
   log_info "Running hook: $hook"


### PR DESCRIPTION
…mode and force rootfs-relabel

Changelog: Title

CentOS 8 converted image cannot boot to login shell:
user: no shell: permission denied

It turns out that issue was caused by selinux. Idea for relabeling rootfs
was inspired by this post:
https://forums.centos.org/viewtopic.php?t=48714

Removing of /.autorelabel after action is done is not necessary.

Signed-off-by: Marek Belisko <marek.belisko@open-nandra.com>


# External Contributor Checklist

🚨 Please review the [guidelines for contributing](https://github.com/mendersoftware/mender/blob/master/CONTRIBUTING.md) to this repository.

- [ ] Make sure that all commits have a [`Changelog`](https://github.com/mendersoftware/mender/blob/master/CONTRIBUTING.md#changelog-tags) tag. If nothing should be added to the Changelog, add a `Changelog: None` tag. If there is a change, add `Changelog: Commit`, or `Changelog: Title`, depending on what should be included in the changelog.

- [ ] Make sure that all commits are signed with [`git --signoff`](https://git-scm.com/book/en/v2/Git-Tools-Signing-Your-Work). Also note that the signoff author must match the author of the commit.

### Description

Please describe your pull request.

Thank you!
