### PR TITLE
Update versions for 2.2.0 release

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -4,12 +4,12 @@ variables:
   S3_BUCKET_NAME: mender-convert-images
   # These variables are present elsewhere in the repository too. Make sure to
   # search for and change them too.
-  MENDER_ARTIFACT_VERSION: master
-  MENDER_CLIENT_VERSION: master
+  MENDER_ARTIFACT_VERSION: 3.4.0
+  MENDER_CLIENT_VERSION: 2.4.0-build2
   # Make sure to update the link in mender-docs to the new one when changing
   # this.
-  RASPBIAN_URL: http://downloads.raspberrypi.org/raspios_lite_armhf/images/raspios_lite_armhf-2020-05-28/2020-05-27-raspios-buster-lite-armhf.zip
-  RASPBIAN_NAME: 2020-05-27-raspios-buster-lite-armhf
+  RASPBIAN_URL: http://downloads.raspberrypi.org/raspios_lite_armhf/images/raspios_lite_armhf-2020-08-24/2020-08-20-raspios-buster-armhf-lite.zip
+  RASPBIAN_NAME: 2020-08-20-raspios-buster-armhf-lite
   MENDER_IMAGE_TESTS_REV: master
 
   DEBIAN_FRONTEND: noninteractive

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ RUN cd /root/pxz && make
 
 FROM ubuntu:20.04
 
-ARG MENDER_ARTIFACT_VERSION=master
+ARG MENDER_ARTIFACT_VERSION=3.4.0
 
 RUN apt-get update && env DEBIAN_FRONTEND=noninteractive apt-get install -y \
 # For 'ar' command to unpack .deb

--- a/configs/mender_convert_config
+++ b/configs/mender_convert_config
@@ -110,7 +110,7 @@ MENDER_PARTITION_ALIGNMENT="8388608"
 # Mender client version
 #
 # This is used to fetch the correct binaries
-MENDER_CLIENT_VERSION="master"
+MENDER_CLIENT_VERSION="2.4.0-build2"
 
 # File storage, containing binary files, do not modify this unless you know
 # what you are doing.


### PR DESCRIPTION
Changelog: Update RaspiOS image to 2020-08-24
Changelog: Update mender-artifact to 3.4.0