### PR TITLE
Revert upgrade of RaspiOS base image

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -8,8 +8,8 @@ variables:
   MENDER_CLIENT_VERSION: 2.4.0-build2
   # Make sure to update the link in mender-docs to the new one when changing
   # this.
-  RASPBIAN_URL: http://downloads.raspberrypi.org/raspios_lite_armhf/images/raspios_lite_armhf-2020-08-24/2020-08-20-raspios-buster-armhf-lite.zip
-  RASPBIAN_NAME: 2020-08-20-raspios-buster-armhf-lite
+  RASPBIAN_URL: http://downloads.raspberrypi.org/raspios_lite_armhf/images/raspios_lite_armhf-2020-05-28/2020-05-27-raspios-buster-lite-armhf.zip
+  RASPBIAN_NAME: 2020-05-27-raspios-buster-lite-armhf
   MENDER_IMAGE_TESTS_REV: master
 
   DEBIAN_FRONTEND: noninteractive


### PR DESCRIPTION
Cancel-changelog: d72261dfc2bc7f1f2c82a999d93b15b94f08bffc
Changelog: Update mender-artifact to 3.4.0