### PR TITLE
MEN-3952: beaglebone: Implement workaround for broken U-Boot and kernel.

### DIFF
--- a/configs/beaglebone_black_base_config
+++ b/configs/beaglebone_black_base_config
@@ -1,24 +1,64 @@
-# Binaries generated with the following script:
-#    https://github.com/mendersoftware/mender-convert-integration-scripts/blob/master/build-uboot-bbb.sh
-
-# There are reported issues with GRUB bootloader integration, fallback to U-boot.
-MENDER_GRUB_EFI_INTEGRATION=n
-
-# We will write a modified bootloader
-MENDER_COPY_BOOT_GAP=n
-
-# 4MB alignment
-MENDER_PARTITION_ALIGNMENT="4194304"
-
-BEAGLEBONE_BLACK_BINARIES="${BEAGLEBONE_BLACK_CONFIG}-2018.07.tar.gz"
+# At the time of writing, the binaries below were uploaded manually. However,
+# they are simply a vanilla U-Boot build of v2020.07, from Ubuntu 18.04, using
+# these commands:
+#   make CROSS_COMPILE=arm-linux-gnueabihf- am335x_boneblack_vboot_defconfig
+#   make CROSS_COMPILE=arm-linux-gnueabihf-
+#   make CROSS_COMPILE=arm-linux-gnueabihf- envtools
+BEAGLEBONE_BLACK_BINARIES="beaglebone_black_uefi-2020.07.tar.gz"
 BEAGLEBONE_BLACK_BINARIES_URL="${MENDER_STORAGE_URL}/mender-convert/uboot/beaglebone/${BEAGLEBONE_BLACK_BINARIES}"
 
-function platform_modify() {
+# At the time of writing, the binaries below were uploaded manually. They are
+# simply a dump of the deb package from the link below, with the addition of the
+# initrd file, which is not part of the package, but which is generated when
+# installed on a live Beaglebone device.
+# Original deb URL: http://repos.rcn-ee.com/debian/pool/main/l/linux-upstream/linux-image-4.19.94-ti-r51_1buster_armhf.deb
+BEAGLEBONE_EFI_COMPATIBLE_KERNEL="linux-image-4.19.94-ti-r51_1buster_armhf-deb-dump.tar.xz"
+BEAGLEBONE_EFI_COMPATIBLE_KERNEL_URL="${MENDER_STORAGE_URL}/mender-convert/beaglebone/kernel/${BEAGLEBONE_EFI_COMPATIBLE_KERNEL}"
+BEAGLEBONE_EFI_COMPATIBLE_KERNEL_VERSION=4.19.94-ti-r51
+
+MENDER_IGNORE_UBOOT_BROKEN_UEFI=1
+MENDER_IGNORE_MISSING_EFI_STUB=1
+
+function beaglebone_fix_broken_uefi_uboot() {
+  log_warn "Attempting to work around broken UEFI support in U-Boot by forcing a newer U-Boot version."
+
   mkdir -p work/bbb/binaries
 
   run_and_log_cmd "wget -q ${BEAGLEBONE_BLACK_BINARIES_URL} -P work/bbb/binaries"
   run_and_log_cmd "tar xzvf work/bbb/binaries/${BEAGLEBONE_BLACK_BINARIES} -C work/bbb/binaries"
 
+  # Place u-boot and MLO into rootfs/boot
+  run_and_log_cmd "sudo mkdir -p work/rootfs/boot"
+  run_and_log_cmd "sudo cp work/bbb/binaries/MLO work/boot/"
+  run_and_log_cmd "sudo cp work/bbb/binaries/u-boot.img work/boot/"
+
+  run_and_log_cmd "sudo install -m 755 work/bbb/binaries/fw_printenv work/rootfs/sbin/fw_printenv"
+  run_and_log_cmd "sudo ln -fs /sbin/fw_printenv work/rootfs/sbin/fw_setenv"
+}
+
+function beaglebone_fix_broken_uefi_kernel() {
+  log_warn "Attempting to work around kernel without EFI stub by using a newer kernel."
+
+  mkdir -p work/bbb/kernel
+  run_and_log_cmd "wget -q $BEAGLEBONE_EFI_COMPATIBLE_KERNEL_URL -P work/bbb/kernel"
+  mkdir -p work/bbb/kernel/extract
+  run_and_log_cmd "tar xJf work/bbb/kernel/$BEAGLEBONE_EFI_COMPATIBLE_KERNEL -C work/bbb/kernel/extract"
+  run_and_log_cmd "cp -r work/bbb/kernel/extract/* work/rootfs/"
+  run_and_log_cmd "ln -sf vmlinuz-$BEAGLEBONE_EFI_COMPATIBLE_KERNEL_VERSION work/rootfs/boot/kernel"
+  run_and_log_cmd "ln -sf initrd.img-$BEAGLEBONE_EFI_COMPATIBLE_KERNEL_VERSION work/rootfs/boot/initrd"
+}
+
+function beaglebone_fix_broken_uefi() {
+  if ! is_uboot_with_uefi_support work/boot-gap.bin; then
+    beaglebone_fix_broken_uefi_uboot
+  fi
+  if ! is_efi_compatible_kernel work/rootfs/boot/$kernel_imagetype; then
+    beaglebone_fix_broken_uefi_kernel
+  fi
+}
+PLATFORM_MODIFY_HOOKS+=(beaglebone_fix_broken_uefi)
+
+function disable_udisks2_service() {
   # Mask udisks2.service, otherwise it will mount the inactive part and we
   # might write an update while it is mounted which often result in
   # corruptions.
@@ -26,14 +66,5 @@ function platform_modify() {
   # TODO: Find a way to only blacklist mmcblk0pX devices instead of masking
   # the service.
   run_and_log_cmd "sudo ln -sf /dev/null work/rootfs/etc/systemd/system/udisks2.service"
-
-  # Place u-boot and MLO into rootfs/boot
-  run_and_log_cmd "sudo mkdir -p work/rootfs/boot"
-  run_and_log_cmd "sudo cp work/bbb/binaries/MLO work/boot/"
-  run_and_log_cmd "sudo cp work/bbb/binaries/u-boot.img work/boot/"
-  run_and_log_cmd "sudo cp work/bbb/binaries/fw_env.config work/rootfs/etc/"
-  run_and_log_cmd "sudo cp work/bbb/binaries/uboot-git-log.txt work/boot"
-
-  run_and_log_cmd "sudo install -m 755 work/bbb/binaries/fw_printenv work/rootfs/sbin/fw_printenv"
-  run_and_log_cmd "sudo ln -fs /sbin/fw_printenv work/rootfs/sbin/fw_setenv"
 }
+PLATFORM_MODIFY_HOOKS+=(disable_udisks2_service)

--- a/configs/beaglebone_black_debian_emmc_config
+++ b/configs/beaglebone_black_debian_emmc_config
@@ -1,7 +1,3 @@
-# Binaries generated with the following script:
-#    https://github.com/mendersoftware/mender-convert-integration-scripts/blob/master/build-uboot-bbb.sh
-
-BEAGLEBONE_BLACK_CONFIG="beaglebone_black_debian_emmc"
 source configs/beaglebone_black_base_config
 MENDER_STORAGE_TOTAL_SIZE_MB="3648"
 MENDER_DEVICE_TYPE="beaglebone-emmc"

--- a/configs/beaglebone_black_debian_sdcard_config
+++ b/configs/beaglebone_black_debian_sdcard_config
@@ -1,4 +1,3 @@
-BEAGLEBONE_BLACK_CONFIG="beaglebone_black_debian_sdcard"
 source configs/beaglebone_black_base_config
 MENDER_DEVICE_TYPE="beaglebone-sdcard"
 MENDER_STORAGE_DEVICE_BASE="/dev/mmcblk0p"

--- a/mender-convert-modify
+++ b/mender-convert-modify
@@ -196,18 +196,18 @@ EOF
 
   run_and_log_cmd "sudo mkdir -p work/boot/EFI/BOOT"
   run_and_log_cmd "sudo cp work/${efi_name} -P work/boot/EFI/BOOT/${efi_target_name}"
+fi
 
-  # Copy dtb directory to the boot partition for use by the bootloader.
-  if [ -d work/rootfs/boot/dtbs ]; then
-    # Look for the first directory that has dtb files. First check the base
-    # folder, then any subfolders in versioned order.
-    for candidate in work/rootfs/boot/dtbs $(find work/rootfs/boot/dtbs/ -maxdepth 1 -type d | sort -V -r); do
-      if [ $(find $candidate -maxdepth 1 -name '*.dtb' | wc -l) -gt 0 ]; then
-        run_and_log_cmd "sudo cp -r $candidate work/boot/dtb"
-        break
-      fi
-    done
-  fi
+# Copy dtb directory to the boot partition for use by the bootloader.
+if [ -d work/rootfs/boot/dtbs ]; then
+  # Look for the first directory that has dtb files. First check the base
+  # folder, then any subfolders in versioned order.
+  for candidate in work/rootfs/boot/dtbs $(find work/rootfs/boot/dtbs/ -maxdepth 1 -type d | sort -V -r); do
+    if [ $(find $candidate -maxdepth 1 -name '*.dtb' | wc -l) -gt 0 ]; then
+      run_and_log_cmd "sudo cp -r $candidate work/boot/dtb"
+      break
+    fi
+  done
 fi
 
 run_and_log_cmd "sudo mkdir -p work/rootfs/data/mender"

--- a/mender-convert-modify
+++ b/mender-convert-modify
@@ -133,9 +133,12 @@ if [ "${MENDER_GRUB_EFI_INTEGRATION}" == "y" ]; then
 mender_rootfsa_part=${MENDER_ROOTFS_PART_A_NUMBER}
 mender_rootfsb_part=${MENDER_ROOTFS_PART_B_NUMBER}
 mender_grub_storage_device=${MENDER_GRUB_STORAGE_DEVICE}
-kernel_imagetype=${kernel_imagetype}
-initrd_imagetype=${initrd_imagetype}
+kernel_imagetype=kernel
+initrd_imagetype=initrd
 EOF
+
+  run_and_log_cmd "ln -s ${kernel_imagetype} work/rootfs/boot/kernel"
+  run_and_log_cmd "ln -s ${initrd_imagetype} work/rootfs/boot/initrd"
 
   # For partuuid support grub.cfg expects dedicated variables to be added
   if [ "${MENDER_ENABLE_PARTUUID}" == "y" ]; then

--- a/mender-convert-modify
+++ b/mender-convert-modify
@@ -137,21 +137,21 @@ kernel_imagetype=${kernel_imagetype}
 initrd_imagetype=${initrd_imagetype}
 EOF
 
-# For partuuid support grub.cfg expects dedicated variables to be added
-if [ "${MENDER_ENABLE_PARTUUID}" == "y" ]; then
-   rootfsa_partuuid=$(disk_get_partuuid_from_device "${root_part_a_device}")
-   rootfsb_partuuid=$(disk_get_partuuid_from_device "${root_part_b_device}")
-   log_info "Using root partition A partuuid in grubenv: $rootfsa_partuuid"
-   log_info "Using root partition B partuuid in grubenv: $rootfsb_partuuid"
-   cat <<- EOF >> work/grub-mender-grubenv-${MENDER_GRUBENV_VERSION}/mender_grubenv_defines
+  # For partuuid support grub.cfg expects dedicated variables to be added
+  if [ "${MENDER_ENABLE_PARTUUID}" == "y" ]; then
+    rootfsa_partuuid=$(disk_get_partuuid_from_device "${root_part_a_device}")
+    rootfsb_partuuid=$(disk_get_partuuid_from_device "${root_part_b_device}")
+    log_info "Using root partition A partuuid in grubenv: $rootfsa_partuuid"
+    log_info "Using root partition B partuuid in grubenv: $rootfsb_partuuid"
+    cat <<- EOF >> work/grub-mender-grubenv-${MENDER_GRUBENV_VERSION}/mender_grubenv_defines
 mender_rootfsa_uuid=${rootfsa_partuuid}
 mender_rootfsb_uuid=${rootfsb_partuuid}
 EOF
-else
-  cat <<- EOF >> work/grub-mender-grubenv-${MENDER_GRUBENV_VERSION}/mender_grubenv_defines
+  else
+    cat <<- EOF >> work/grub-mender-grubenv-${MENDER_GRUBENV_VERSION}/mender_grubenv_defines
 mender_kernel_root_base=${MENDER_STORAGE_DEVICE_BASE}
 EOF
-fi
+  fi
 
   if [ -n "${MENDER_GRUB_KERNEL_BOOT_ARGS}" ]; then
     cat <<- EOF > work/grub-mender-grubenv-${MENDER_GRUBENV_VERSION}/11_bootargs_grub.cfg
@@ -174,8 +174,8 @@ EOF
   sudo rm -rf work/boot/EFI/systemd
   sudo rm -rf work/boot/NvVars
   for empty_dir in $(cd work/boot; find . -maxdepth 1 -type d -empty); do
-      sudo rmdir work/boot/$empty_dir
-      sudo rm work/rootfs/boot/$empty_dir
+    sudo rmdir work/boot/$empty_dir
+    sudo rm work/rootfs/boot/$empty_dir
   done
 
   log_info "Installing GRUB"

--- a/modules/disk.sh
+++ b/modules/disk.sh
@@ -100,7 +100,7 @@ disk_align_sectors() {
 # $2 - destination file
 # $3 - offset in number of 512 sectors
 disk_write_at_offset() {
-  run_and_log_cmd "dd if=${1} of=${2} seek=${3} conv=sparse,notrunc status=none"
+  run_and_log_cmd "dd if=${1} of=${2} seek=${3} conv=notrunc status=none"
 }
 
 # Create file system image from directory content

--- a/scripts/test/run-tests.sh
+++ b/scripts/test/run-tests.sh
@@ -102,18 +102,20 @@ else
 
   if [ "$1" == "--all" -o "$1" == "--only" -a "$2" == "beaglebone" ]; then
     wget --progress=dot:giga -N ${BBB_DEBIAN_IMAGE_URL} -P input/
-    convert_and_test "beaglebone" \
+    convert_and_test "beaglebone-sdcard" \
                      "release-1" \
-                     "input/bone-debian-9.5-iot-armhf-2018-08-30-4gb.img.xz" || test_result=$?
+                     "input/bone-debian-9.5-iot-armhf-2018-08-30-4gb.img.xz" \
+                     "--config configs/beaglebone_black_debian_sdcard_config" || test_result=$?
 
     echo >&2 "----------------------------------------"
     echo >&2 "Running the uncompressed test"
     echo >&2 "----------------------------------------"
     rm -rf deploy
     unxz --force "input/bone-debian-9.5-iot-armhf-2018-08-30-4gb.img.xz"
-    convert_and_test "beaglebone" \
+    convert_and_test "beaglebone-emmc" \
                      "release-1" \
-                     "input/bone-debian-9.5-iot-armhf-2018-08-30-4gb.img" || test_result=$?
+                     "input/bone-debian-9.5-iot-armhf-2018-08-30-4gb.img" \
+                     "--config configs/beaglebone_black_debian_emmc_config" || test_result=$?
   fi
 
   if [ "$1" == "--all" -o "$1" == "--only" -a "$2" == "ubuntu" ]; then

--- a/scripts/test/run-tests.sh
+++ b/scripts/test/run-tests.sh
@@ -15,7 +15,9 @@ fi
 
 WORKSPACE=./tests
 
-BBB_DEBIAN_IMAGE_URL="http://debian.beagleboard.org/images/bone-debian-9.5-iot-armhf-2018-08-30-4gb.img.xz"
+BBB_DEBIAN_SDCARD_IMAGE_URL="https://debian.beagleboard.org/images/bone-debian-10.3-iot-armhf-2020-04-06-4gb.img.xz"
+# Not on official home page, but found via https://elinux.org/Beagleboard:BeagleBoneBlack_Debian:
+BBB_DEBIAN_EMMC_IMAGE_URL="https://rcn-ee.com/rootfs/bb.org/testing/2020-09-21/buster-console/bone-debian-10.5-console-armhf-2020-09-21-1gb.img.xz"
 
 RASPBIAN_IMAGE_URL="http://downloads.raspberrypi.org/raspbian_lite/images/raspbian_lite-2019-09-30/2019-09-26-raspbian-buster-lite.zip"
 
@@ -101,20 +103,21 @@ else
   fi
 
   if [ "$1" == "--all" -o "$1" == "--only" -a "$2" == "beaglebone" ]; then
-    wget --progress=dot:giga -N ${BBB_DEBIAN_IMAGE_URL} -P input/
+    wget --progress=dot:giga -N ${BBB_DEBIAN_SDCARD_IMAGE_URL} -P input/
     convert_and_test "beaglebone-sdcard" \
                      "release-1" \
-                     "input/bone-debian-9.5-iot-armhf-2018-08-30-4gb.img.xz" \
+                     "input/bone-debian-10.3-iot-armhf-2020-04-06-4gb.img.xz" \
                      "--config configs/beaglebone_black_debian_sdcard_config" || test_result=$?
 
     echo >&2 "----------------------------------------"
     echo >&2 "Running the uncompressed test"
     echo >&2 "----------------------------------------"
     rm -rf deploy
-    unxz --force "input/bone-debian-9.5-iot-armhf-2018-08-30-4gb.img.xz"
+    wget --progress=dot:giga -N ${BBB_DEBIAN_EMMC_IMAGE_URL} -P input/
+    unxz --force "input/bone-debian-10.5-console-armhf-2020-09-21-1gb.img.xz"
     convert_and_test "beaglebone-emmc" \
                      "release-1" \
-                     "input/bone-debian-9.5-iot-armhf-2018-08-30-4gb.img" \
+                     "input/bone-debian-10.5-console-armhf-2020-09-21-1gb.img" \
                      "--config configs/beaglebone_black_debian_emmc_config" || test_result=$?
   fi
 


### PR DESCRIPTION
Several smaller fixes, but this is the main one:

```
commit 8c629c0612f43b36e2c53848b2b5a6e834f5968c
Author: Kristian Amlie <kristian.amlie@northern.tech>
Date:   Mon Sep 21 19:54:03 2020

    MEN-3952: beaglebone: Implement workaround for broken U-Boot and kernel.
    
    Originally the intention was to fix the U-Boot integration for
    Beaglebone, but this seems to have been broken for a long time, almost
    a year, and no one has complained about it. The problem appears to be
    connected to this commit [1], but it's not entirely clear to me what
    the fix should be, and there are a lot of patches for our U-Boot fork.
    
    However, since the U-Boot integration is supposed to be the backup
    solution, rather than dig into U-Boot I decided to just fix the UEFI
    path instead. This method doesn't require any patching, but there is
    a problem with the specific image which is available for download at
    the time of writing. So just grab the boot loader and kernel pieces
    from a later, yet unbuilt, image, and it all works again.
    
    Changelog: Title
    
    Changelog: beaglebone: Remove U-Boot integration, which has not worked
    for a long time. U-Boot will still be used for booting, but GRUB will
    be used for integration with Mender, by chainloading via UEFI.
    
    [1] https://github.com/mendersoftware/uboot-mender/commit/e88d5dbf01dc8c3822c695267b43d6000d9b2a19
    
    Signed-off-by: Kristian Amlie <kristian.amlie@northern.tech>
```