### PR TITLE
Add support for overlay hooks

### DIFF
--- a/mender-convert-modify
+++ b/mender-convert-modify
@@ -26,6 +26,11 @@ function user_local_modify() {
 }
 USER_LOCAL_MODIFY_HOOKS=(user_local_modify)
 
+function overlay_modify() {
+  true
+}
+OVERLAY_MODIFY_HOOKS=(overlay_modify)
+
 function trap_exit() {
   echo "mender-convert-modify has finished. Cleaning up..."
   sudo umount -f work/boot
@@ -310,4 +315,10 @@ done
 for overlay in "${overlays[@]}"; do
   log_info "Applying rootfs overlay: ${overlay}"
   run_and_log_cmd "sudo rsync --archive --keep-dirlinks --verbose ${overlay}/ work/rootfs/"
+done
+
+log_info "Performing overlay specific modifications (if any)"
+for hook in "${OVERLAY_MODIFY_HOOKS[@]}"; do
+  log_info "Running hook: $hook"
+  eval $hook
 done


### PR DESCRIPTION
Changelog: Add support for overlay hooks

I find this hook very useful because you might what to be sure the certain files have the right permissions and owner.
In my scenario some of the files needs to be owned by root, but I don't want to have to become root in order to edit an overlay file/folder.
Also, during development a developer might submit a file/folder with wrong permissions. 
