### PR TITLE
[tests, CI, dependabot] Remove --no-pull, update tests, add dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,9 @@
+version: 2
+updates:
+  - commit-message:
+      prefix: "Changelog:All"
+    directory: /
+    package-ecosystem: gitsubmodule
+    schedule:
+      interval: weekly
+

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -10,7 +10,6 @@ variables:
   # this.
   RASPBIAN_URL: http://downloads.raspberrypi.org/raspios_lite_armhf/images/raspios_lite_armhf-2020-05-28/2020-05-27-raspios-buster-lite-armhf.zip
   RASPBIAN_NAME: 2020-05-27-raspios-buster-lite-armhf
-  MENDER_IMAGE_TESTS_REV: master
 
   DEBIAN_FRONTEND: noninteractive
 
@@ -109,8 +108,8 @@ convert_raspbian_raspberrypi4:
     # Load image under test
     - export IMAGE_NAME=$DOCKER_REPOSITORY:pr
     - docker load -i image.tar
-    # Set submodule to correct version
-    - ( cd tests/mender-image-tests && git submodule update --init --remote && git checkout origin/${MENDER_IMAGE_TESTS_REV} )
+    # Set mender-image-tests submodule to correct version
+    - git submodule update --init --recursive
   artifacts:
     expire_in: 2w
     when: always
@@ -129,7 +128,7 @@ convert_raspbian_raspberrypi4:
     - mv ${RASPBERRYPI_PLATFORM} deploy
     # Extract converted Raspbian artifacts
     - unxz deploy/${RASPBIAN_NAME}-${RASPBERRYPI_PLATFORM}-mender.img.xz
-    - ./scripts/test/run-tests.sh --no-pull --prebuilt-image raspberrypi ${RASPBIAN_NAME}-${RASPBERRYPI_PLATFORM}-mender
+    - ./scripts/test/run-tests.sh --prebuilt-image raspberrypi ${RASPBIAN_NAME}-${RASPBERRYPI_PLATFORM}-mender
 
 test_acceptance_prebuilt_raspberrypi3:
   <<: *test_acceptance_prebuilt_raspberrypi
@@ -150,27 +149,27 @@ test_acceptance_prebuilt_raspberrypi4:
 test_acceptance_qemux86_64:
   <<: *test_acceptance
   script:
-    - ./scripts/test/run-tests.sh --no-pull --only qemux86_64
+    - ./scripts/test/run-tests.sh --only qemux86_64
 
 test_acceptance_raspberrypi:
   <<: *test_acceptance
   script:
-    - ./scripts/test/run-tests.sh --no-pull --only raspberrypi3
+    - ./scripts/test/run-tests.sh --only raspberrypi3
 
 test_acceptance_linaro-alip:
   <<: *test_acceptance
   script:
-    - ./scripts/test/run-tests.sh --no-pull --only linaro-alip
+    - ./scripts/test/run-tests.sh --only linaro-alip
 
 test_acceptance_beaglebone:
   <<: *test_acceptance
   script:
-    - ./scripts/test/run-tests.sh --no-pull --only beaglebone
+    - ./scripts/test/run-tests.sh --only beaglebone
 
 test_acceptance_ubuntu:
   <<: *test_acceptance
   script:
-    - ./scripts/test/run-tests.sh --no-pull --only ubuntu
+    - ./scripts/test/run-tests.sh --only ubuntu
 
 publish:s3:
   when: manual

--- a/.gitmodules
+++ b/.gitmodules
@@ -2,4 +2,3 @@
 	path = tests/mender-image-tests
 	url = https://github.com/mendersoftware/mender-image-tests
 	branch = master
-	ignore = all

--- a/scripts/test/run-tests.sh
+++ b/scripts/test/run-tests.sh
@@ -3,7 +3,7 @@
 set -e
 
 usage() {
-  echo "$0 [--no-pull] <--all | --only DEVICE_TYPE | --prebuilt-image DEVICE_TYPE IMAGE_NAME>"
+  echo "$0 <--all | --only DEVICE_TYPE | --prebuilt-image DEVICE_TYPE IMAGE_NAME>"
   exit 1
 }
 
@@ -33,13 +33,6 @@ source $UTILS_PATH
 
 # Some distros do not have /sbin in path for "normal users"
 export PATH="${PATH}:/sbin"
-
-if [ "$1" = "--no-pull" ]; then
-  shift
-else
-  echo "Automatically pulling submodules. Use --no-pull to disable"
-  git submodule update --init --remote
-fi
 
 mkdir -p ${WORKSPACE}
 

--- a/scripts/test/test-utils.sh
+++ b/scripts/test/test-utils.sh
@@ -136,6 +136,7 @@ run_tests() {
 get_pytest_files() {
   wget -N ${MENDER_ACCEPTANCE_URL}/pytest.ini -P $WORKSPACE/mender-image-tests
   wget -N ${MENDER_ACCEPTANCE_URL}/common.py -P $WORKSPACE/mender-image-tests
+  wget -N ${MENDER_ACCEPTANCE_URL}/helpers.py -P $WORKSPACE/mender-image-tests
   wget -N ${MENDER_ACCEPTANCE_URL}/conftest.py -P $WORKSPACE/mender-image-tests
   wget -N ${MENDER_ACCEPTANCE_URL}/fixtures.py -P $WORKSPACE/mender-image-tests
 }


### PR DESCRIPTION
Remove all the logic for the special handling of this submodule, and
treat it instead a regular Git submodule.

This commit updates the submodule to latest, removes the --no-pull
functionality, and removes the ignore of the submodule to make
developers aware

To ease maintenance, add also dependabot to pay attention to the future
updates of the submodule.