### PR TITLE
Do not compress output image for uncompressed input image

### DIFF
--- a/mender-convert
+++ b/mender-convert
@@ -24,7 +24,8 @@ touch work/convert.log
 ###############################################################################
 #                Declaration of important variables for this file             #
 ###############################################################################
-declare override_extraargs="" # Override arguments passed to the sub-scripts
+declare prepend_extraargs=""  # Default arguments passed to the sub-scripts
+declare append_extraargs=""   # Override arguments passed to the sub-scripts
 declare compression_type=""   # Detected input file compression, also applied to the output
 declare ocfile="./work/override_compression_config"
 declare disk_image=""         # Needed in parse_cli_options, and is passed to decompress_image()
@@ -119,17 +120,17 @@ fi
 
 parse_cli_options "$@"
 
-uncompressed_disk_image="${disk_image}"
 compression_type=$(compression_type "${disk_image}")
 if [[ ${compression_type} != "none" ]]; then
   uncompressed_disk_image=$(decompress_image "${disk_image}" "./work")
   echo "MENDER_COMPRESS_DISK_IMAGE=${compression_type}" > ${ocfile}
-  override_extraargs="--disk-image ${uncompressed_disk_image} --config ${ocfile}"
+  prepend_extraargs="--config ${ocfile}"
+  append_extraargs="--disk-image ${uncompressed_disk_image}"
 fi
 
-./mender-convert-extract "$@" ${override_extraargs}
-./mender-convert-modify  "$@" ${override_extraargs}
-./mender-convert-package "$@" ${override_extraargs}
+./mender-convert-extract ${prepend_extraargs} "$@" ${append_extraargs}
+./mender-convert-modify  ${prepend_extraargs} "$@" ${append_extraargs}
+./mender-convert-package ${prepend_extraargs} "$@" ${append_extraargs}
 
 echo "Output Artifacts and images can be found in the deploy directory:"
 ls -1 deploy/*

--- a/mender-convert
+++ b/mender-convert
@@ -123,10 +123,10 @@ parse_cli_options "$@"
 compression_type=$(compression_type "${disk_image}")
 if [[ ${compression_type} != "none" ]]; then
   uncompressed_disk_image=$(decompress_image "${disk_image}" "./work")
-  echo "MENDER_COMPRESS_DISK_IMAGE=${compression_type}" > ${ocfile}
-  prepend_extraargs="--config ${ocfile}"
   append_extraargs="--disk-image ${uncompressed_disk_image}"
 fi
+echo "MENDER_COMPRESS_DISK_IMAGE=${compression_type}" > ${ocfile}
+prepend_extraargs="--config ${ocfile}"
 
 ./mender-convert-extract ${prepend_extraargs} "$@" ${append_extraargs}
 ./mender-convert-modify  ${prepend_extraargs} "$@" ${append_extraargs}

--- a/scripts/test/run-tests.sh
+++ b/scripts/test/run-tests.sh
@@ -61,10 +61,12 @@ else
     echo >&2 "----------------------------------------"
     rm -rf deploy
     gunzip --force "input/Ubuntu-Bionic-x86-64.img.gz"
-    convert_and_test "qemux86_64" \
-                     "release-1" \
-                     "input/Ubuntu-Bionic-x86-64.img" \
-                     "--config configs/qemux86-64_config" || test_result=$?
+    run_convert "release-2" \
+                "input/Ubuntu-Bionic-x86-64.img" \
+                "--config configs/qemux86-64_config" || test_result=$?
+    ret=0
+    test -f deploy/Ubuntu-Bionic-x86-64-qemux86_64-mender.img || ret=$?
+    assert "${ret}" "0" "Expected uncompressed file deploy/Ubuntu-Bionic-x86-64-qemux86_64-mender.img"
   fi
 
   if [ "$1" == "--all" -o "$1" == "--only" -a "$2" == "raspberrypi3" ]; then
@@ -72,16 +74,6 @@ else
     convert_and_test "raspberrypi3" \
                      "release-1" \
                      "input/2019-09-26-raspbian-buster-lite.zip" \
-                     "--config configs/raspberrypi3_config" || test_result=$?
-
-    echo >&2 "----------------------------------------"
-    echo >&2 "Running the uncompressed test"
-    echo >&2 "----------------------------------------"
-    rm -rf deploy
-    unzip -o "input/2019-09-26-raspbian-buster-lite.zip" -d "./input"
-    convert_and_test "raspberrypi3" \
-                     "release-1" \
-                     "input/2019-09-26-raspbian-buster-lite.img" \
                      "--config configs/raspberrypi3_config" || test_result=$?
   fi
 
@@ -101,17 +93,6 @@ else
                      "release-1" \
                      "input/bone-debian-10.3-iot-armhf-2020-04-06-4gb.img.xz" \
                      "--config configs/beaglebone_black_debian_sdcard_config" || test_result=$?
-
-    echo >&2 "----------------------------------------"
-    echo >&2 "Running the uncompressed test"
-    echo >&2 "----------------------------------------"
-    rm -rf deploy
-    wget --progress=dot:giga -N ${BBB_DEBIAN_EMMC_IMAGE_URL} -P input/
-    unxz --force "input/bone-debian-10.5-console-armhf-2020-09-21-1gb.img.xz"
-    convert_and_test "beaglebone-emmc" \
-                     "release-1" \
-                     "input/bone-debian-10.5-console-armhf-2020-09-21-1gb.img" \
-                     "--config configs/beaglebone_black_debian_emmc_config" || test_result=$?
   fi
 
   if [ "$1" == "--all" -o "$1" == "--only" -a "$2" == "ubuntu" ]; then
@@ -119,16 +100,6 @@ else
     convert_and_test "raspberrypi3" \
                      "release-1" \
                      "input/ubuntu-18.04.5-preinstalled-server-armhf+raspi3.img.xz" \
-                     "--config configs/raspberrypi3_config" || test_result=$?
-
-    echo >&2 "----------------------------------------"
-    echo >&2 "Running the uncompressed test"
-    echo >&2 "----------------------------------------"
-    rm -rf deploy
-    unxz --force "input/ubuntu-18.04.5-preinstalled-server-armhf+raspi3.img.xz"
-    convert_and_test "raspberrypi3" \
-                     "release-1" \
-                     "input/ubuntu-18.04.5-preinstalled-server-armhf+raspi3.img" \
                      "--config configs/raspberrypi3_config" || test_result=$?
   fi
 

--- a/scripts/test/test-utils.sh
+++ b/scripts/test/test-utils.sh
@@ -61,11 +61,10 @@ convert_and_test() {
   device_type=$1
   artifact_name=$2
   image_file=$3
-  extra_args=$4 # Optional
+  shift 3
+  extra_args=$@ # Optional
 
-  MENDER_ARTIFACT_NAME=${artifact_name} ./docker-mender-convert \
-                      --disk-image ${image_file} \
-                      ${extra_args}
+  run_convert ${artifact_name} ${image_file} ${extra_args}
 
   local compression="${image_file##*.}"
   local ret=0
@@ -79,6 +78,18 @@ convert_and_test() {
   run_tests "${device_type}"  "$(basename ${converted_image_uncompressed})" || ret=$?
 
   assert "${ret}" "0" "Failed to convert ${image_file}"
+
+}
+
+run_convert() {
+  artifact_name=$1
+  image_file=$2
+  shift 2
+  extra_args=$@ # Optional
+
+  MENDER_ARTIFACT_NAME=${artifact_name} ./docker-mender-convert \
+                      --disk-image ${image_file} \
+                      ${extra_args}
 
 }
 

--- a/scripts/test/test-utils.sh
+++ b/scripts/test/test-utils.sh
@@ -105,14 +105,6 @@ run_tests() {
     html_report_args="--html=${MENDER_CONVERT_DIR}/report_${device_type}.html --self-contained-html"
   fi
 
-  # Need to decompress images built with MENDER_COMPRESS_DISK_IMAGE=gzip before
-  # running tests.
-  if [ -f "deploy/${converted_image_name}.img.gz" ]; then
-    # sudo is needed because the image is created using docker-mender-convert
-    # which sets root permissions on the image
-    sudo gunzip --force "deploy/${converted_image_name}.img.gz"
-  fi
-
   # MEN-3051: Rename the files back to .sdimg, as the sdimg extension has meaning
   # in the test-infrastructure.
   for file in ${MENDER_CONVERT_DIR}/deploy/*.img; do

--- a/scripts/test/test-utils.sh
+++ b/scripts/test/test-utils.sh
@@ -63,8 +63,6 @@ convert_and_test() {
   image_file=$3
   extra_args=$4 # Optional
 
-  rm -f ${WORKSPACE}/test_config
-
   MENDER_ARTIFACT_NAME=${artifact_name} ./docker-mender-convert \
                       --disk-image ${image_file} \
                       ${extra_args}


### PR DESCRIPTION
The two main commits are:

* Support overriding default image compression
The default behavior is not changing, but splitting the arguments in
prepend/append allows the user to override the output image compression.

* Do not compress output image for uncompressed input image
Respecting this way always the input type (compressed or not) by
default, allowing the user to override behaviour if desired.
For the tests, removed the unnecessary duplication on rerunning all
tests on uncompressed versions, and added instead an explicit test only
for qemu-x86_64.
