### PR TITLE
QA-214: Package 'latest' Mender client debian package by default

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -5,7 +5,7 @@ variables:
   # These variables are present elsewhere in the repository too. Make sure to
   # search for and change them too.
   MENDER_ARTIFACT_VERSION: master
-  MENDER_CLIENT_VERSION: master
+  MENDER_CLIENT_VERSION: latest
   # Make sure to update the link in mender-docs to the new one when changing
   # this.
   RASPBIAN_URL: http://downloads.raspberrypi.org/raspios_lite_armhf/images/raspios_lite_armhf-2020-05-28/2020-05-27-raspios-buster-lite-armhf.zip

--- a/configs/mender_convert_config
+++ b/configs/mender_convert_config
@@ -111,7 +111,7 @@ MENDER_PARTITION_ALIGNMENT="8388608"
 # Mender client version
 #
 # This is used to fetch the correct binaries
-MENDER_CLIENT_VERSION="master"
+MENDER_CLIENT_VERSION="latest"
 
 # File storage, containing binary files, do not modify this unless you know
 # what you are doing.

--- a/mender-convert-modify
+++ b/mender-convert-modify
@@ -100,7 +100,11 @@ mkdir -p work/mender-deb/files
 log_info "Installing Mender client and related files"
 
 deb_arch=$(probe_debian_arch_name)
-deb_name="mender-client_${MENDER_CLIENT_VERSION}-1_${deb_arch}.deb"
+DEBIAN_REVISION="-1"
+if [ "${MENDER_CLIENT_VERSION}" = "latest" ]; then
+  DEBIAN_REVISION=""
+fi
+deb_name="mender-client_${MENDER_CLIENT_VERSION}${DEBIAN_REVISION}_${deb_arch}.deb"
 run_and_log_cmd "wget -Nq ${MENDER_STORAGE_URL}/${MENDER_CLIENT_VERSION}/dist-packages/debian/${deb_arch}/${deb_name} -P work/mender-deb"
 
 cd work/mender-deb


### PR DESCRIPTION
This cannot be merged until https://github.com/mendersoftware/mender-dist-packages/pull/34 is in, and a latest package is merged obviously.
