### PR TITLE
Remove the 'only' tag from the publish job

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -206,6 +206,3 @@ publish:s3:
     -   aws s3api put-object-acl --acl public-read --bucket $S3_BUCKET_NAME
           --key ${RASPBIAN_NAME}/arm/${PUBLISH_NAME}
     - done
-
-  only:
-    - /^(master|[0-9]+\.[0-9]+\.x)$/


### PR DESCRIPTION
It is already manual, so really no need for the 'only' tag.

Changelog: None

Signed-off-by: Ole Petter <ole.orhagen@northern.tech>
(cherry picked from commit 23d169a4b291354ea0505dbc6f7622e2babab2bc)
