### PR TITLE
Bump MENDER_CLIENT_VERSION to 2.4.1

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -5,7 +5,7 @@ variables:
   # These variables are present elsewhere in the repository too. Make sure to
   # search for and change them too.
   MENDER_ARTIFACT_VERSION: 3.4.0
-  MENDER_CLIENT_VERSION: 2.4.0
+  MENDER_CLIENT_VERSION: 2.4.1
   # Make sure to update the link in mender-docs to the new one when changing
   # this.
   RASPBIAN_URL: http://downloads.raspberrypi.org/raspios_lite_armhf/images/raspios_lite_armhf-2020-05-28/2020-05-27-raspios-buster-lite-armhf.zip

--- a/configs/mender_convert_config
+++ b/configs/mender_convert_config
@@ -111,7 +111,7 @@ MENDER_PARTITION_ALIGNMENT="8388608"
 # Mender client version
 #
 # This is used to fetch the correct binaries
-MENDER_CLIENT_VERSION="2.4.0"
+MENDER_CLIENT_VERSION="2.4.1"
 
 # File storage, containing binary files, do not modify this unless you know
 # what you are doing.


### PR DESCRIPTION
Changelog: Install the latest Mender-client release (2.4.1) by default.

Signed-off-by: Ole Petter <ole.orhagen@northern.tech>
