### PR TITLE
[RFC] Use separate chown and chgrp commands when creating rootfs overlay.

### DIFF
--- a/scripts/bootstrap-rootfs-overlay-demo-server.sh
+++ b/scripts/bootstrap-rootfs-overlay-demo-server.sh
@@ -52,7 +52,10 @@ if [ -z "${server_ip}" ]; then
   exit 1
 fi
 
-[ -e ${output_dir} ] && sudo chown -R $(id -u).$(id -g) ${output_dir}
+if [ -e ${output_dir} ]; then
+     sudo chown -R $(id -u) ${output_dir}
+     sudo chgrp -R $(id -g) ${output_dir}
+fi
 mkdir -p ${output_dir}/etc/mender
 cat <<- EOF > ${output_dir}/etc/mender/mender.conf
 {
@@ -78,6 +81,7 @@ ${server_ip} docker.mender.io s3.docker.mender.io
 EOF
 wget -q "https://raw.githubusercontent.com/mendersoftware/mender/master/support/demo.crt" -O ${output_dir}/etc/mender/server.crt
 
-sudo chown -R root.root ${output_dir}
+sudo chown -R root ${output_dir}
+sudo chgrp -R root ${output_dir}
 
 echo "Configuration file for using Demo Mender Server written to: ${output_dir}/etc/mender"

--- a/scripts/bootstrap-rootfs-overlay-hosted-server.sh
+++ b/scripts/bootstrap-rootfs-overlay-hosted-server.sh
@@ -53,7 +53,10 @@ if [ -z "${tenant_token}" ]; then
   exit 1
 fi
 
-[ -e ${output_dir} ] && sudo chown -R $(id -u).$(id -g) ${output_dir}
+if [ -e ${output_dir} ]; then
+     sudo chown -R $(id -u) ${output_dir}
+     sudo chgrp -R $(id -g) ${output_dir}
+fi
 mkdir -p ${output_dir}/etc/mender
 cat <<- EOF > ${output_dir}/etc/mender/mender.conf
 {
@@ -67,6 +70,7 @@ EOF
 
 chmod 600 ${output_dir}/etc/mender/mender.conf
 
-sudo chown -R root.root ${output_dir}
+sudo chown -R root ${output_dir}
+sudo chgrp -R root ${output_dir}
 
 echo "Configuration file for using Hosted Mender written to: ${output_dir}/etc/mender"

--- a/scripts/bootstrap-rootfs-overlay-production-server.sh
+++ b/scripts/bootstrap-rootfs-overlay-production-server.sh
@@ -57,7 +57,10 @@ if [ -z "${server_url}" ]; then
   exit 1
 fi
 
-[ -e ${output_dir} ] && sudo chown -R $(id -u).$(id -g) ${output_dir}
+if [ -e ${output_dir} ]; then
+    sudo chown -R $(id -u) ${output_dir}
+    sudo chgrp -R $(id -g) ${output_dir}
+fi
 mkdir -p ${output_dir}/etc/mender
 cat <<- EOF > ${output_dir}/etc/mender/mender.conf
 {
@@ -80,6 +83,7 @@ EOF
 
 chmod 600 ${output_dir}/etc/mender/mender.conf
 
-sudo chown -R root.root ${output_dir}
+sudo chown -R root ${output_dir}
+sudo chgrp -R root ${output_dir}
 
 echo "Configuration file for using Production Mender Server written to: ${output_dir}/etc/mender"


### PR DESCRIPTION
This is needed for MacOS compatibility as the default chown version there does
not understand the user.group syntax.

Signed-off-by: Drew Moseley <drew.moseley@northern.tech>


# External Contributor Checklist

🚨 Please review the [guidelines for contributing](https://github.com/mendersoftware/mender/blob/master/CONTRIBUTING.md) to this repository.

- [ ] Make sure that all commits have a [`Changelog`](https://github.com/mendersoftware/mender/blob/master/CONTRIBUTING.md#changelog-tags) tag. If nothing should be added to the Changelog, add a `Changelog: None` tag. If there is a change, add `Changelog: Commit`, or `Changelog: Title`, depending on what should be included in the changelog.

- [ ] Make sure that all commits are signed with [`git --signoff`](https://git-scm.com/book/en/v2/Git-Tools-Signing-Your-Work). Also note that the signoff author must match the author of the commit.

### Description

Please describe your pull request.

Thank you!
