### PR TITLE
[2.2.x] mender-convert-modify: remove superfluous 'rm' in empty dir cleanup

### DIFF
--- a/mender-convert-modify
+++ b/mender-convert-modify
@@ -184,7 +184,6 @@ EOF
   sudo rm -rf work/boot/NvVars
   for empty_dir in $(cd work/boot; find . -maxdepth 1 -type d -empty); do
     sudo rmdir work/boot/$empty_dir
-    sudo rm work/rootfs/boot/$empty_dir
   done
 
   log_info "Installing GRUB"


### PR DESCRIPTION
Porting #274 