### PR TITLE
Use numeric uid and gid for better cross-compatibility.

### DIFF
--- a/scripts/bootstrap-rootfs-overlay-demo-server.sh
+++ b/scripts/bootstrap-rootfs-overlay-demo-server.sh
@@ -91,7 +91,7 @@ ${server_ip} docker.mender.io s3.docker.mender.io
 EOF
 wget -q "https://raw.githubusercontent.com/mendersoftware/mender/master/support/demo.crt" -O ${output_dir}/etc/mender/server.crt
 
-sudo chown -R root ${output_dir}
-sudo chgrp -R root ${output_dir}
+sudo chown -R 0 ${output_dir}
+sudo chgrp -R 0 ${output_dir}
 
 echo "Configuration file for using Demo Mender Server written to: ${output_dir}/etc/mender"

--- a/scripts/bootstrap-rootfs-overlay-hosted-server.sh
+++ b/scripts/bootstrap-rootfs-overlay-hosted-server.sh
@@ -70,7 +70,7 @@ EOF
 
 chmod 600 ${output_dir}/etc/mender/mender.conf
 
-sudo chown -R root ${output_dir}
-sudo chgrp -R root ${output_dir}
+sudo chown -R 0 ${output_dir}
+sudo chgrp -R 0 ${output_dir}
 
 echo "Configuration file for using Hosted Mender written to: ${output_dir}/etc/mender"

--- a/scripts/bootstrap-rootfs-overlay-production-server.sh
+++ b/scripts/bootstrap-rootfs-overlay-production-server.sh
@@ -83,7 +83,7 @@ EOF
 
 chmod 600 ${output_dir}/etc/mender/mender.conf
 
-sudo chown -R root ${output_dir}
-sudo chgrp -R root ${output_dir}
+sudo chown -R 0 ${output_dir}
+sudo chgrp -R 0 ${output_dir}
 
 echo "Configuration file for using Production Mender Server written to: ${output_dir}/etc/mender"


### PR DESCRIPTION
Ubuntu calls group 0 "root" but MacOS calls it "wheel".  This change allows
the same code to function on both.