### PR TITLE
[run-tests.sh] Restore BBB eMMC convert/test and update image

### DIFF
--- a/scripts/test/run-tests.sh
+++ b/scripts/test/run-tests.sh
@@ -101,10 +101,23 @@ else
 
   if [ "$1" == "--all" -o "$1" == "--only" -a "$2" == "beaglebone" ]; then
     wget --progress=dot:giga -N ${BBB_DEBIAN_SDCARD_IMAGE_URL} -P input/
+    # Convert uncompressed images to speed up this job
+    unxz --force "input/bone-debian-10.3-iot-armhf-2020-04-06-4gb.img.xz"
     convert_and_test "beaglebone-sdcard" \
                      "release-1" \
-                     "input/bone-debian-10.3-iot-armhf-2020-04-06-4gb.img.xz" \
+                     "input/bone-debian-10.3-iot-armhf-2020-04-06-4gb.img" \
                      "--config configs/beaglebone_black_debian_sdcard_config" \
+                     -- \
+                     "-k" "'not test_update'" \
+                     || test_result=$?
+
+    rm -rf deploy
+    wget --progress=dot:giga -N ${BBB_DEBIAN_EMMC_IMAGE_URL} -P input/
+    unxz --force "input/bone-debian-10.5-console-armhf-2020-09-21-1gb.img.xz"
+    convert_and_test "beaglebone-emmc" \
+                     "release-1" \
+                     "input/bone-debian-10.5-console-armhf-2020-09-21-1gb.img" \
+                     "--config configs/beaglebone_black_debian_emmc_config" \
                      -- \
                      "-k" "'not test_update'" \
                      || test_result=$?

--- a/scripts/test/run-tests.sh
+++ b/scripts/test/run-tests.sh
@@ -17,7 +17,7 @@ WORKSPACE=./tests
 
 BBB_DEBIAN_SDCARD_IMAGE_URL="https://debian.beagleboard.org/images/bone-debian-10.3-iot-armhf-2020-04-06-4gb.img.xz"
 # Not on official home page, but found via https://elinux.org/Beagleboard:BeagleBoneBlack_Debian:
-BBB_DEBIAN_EMMC_IMAGE_URL="https://rcn-ee.com/rootfs/bb.org/testing/2020-09-21/buster-console/bone-debian-10.5-console-armhf-2020-09-21-1gb.img.xz"
+BBB_DEBIAN_EMMC_IMAGE_URL="https://rcn-ee.com/rootfs/bb.org/testing/2021-01-11/buster-console/bone-debian-10.7-console-armhf-2021-01-11-1gb.img.xz"
 
 RASPBIAN_IMAGE_URL="http://downloads.raspberrypi.org/raspbian_lite/images/raspbian_lite-2019-09-30/2019-09-26-raspbian-buster-lite.zip"
 
@@ -113,10 +113,10 @@ else
 
     rm -rf deploy
     wget --progress=dot:giga -N ${BBB_DEBIAN_EMMC_IMAGE_URL} -P input/
-    unxz --force "input/bone-debian-10.5-console-armhf-2020-09-21-1gb.img.xz"
+    unxz --force "input/bone-debian-10.7-console-armhf-2021-01-11-1gb.img.xz"
     convert_and_test "beaglebone-emmc" \
                      "release-1" \
-                     "input/bone-debian-10.5-console-armhf-2020-09-21-1gb.img" \
+                     "input/bone-debian-10.7-console-armhf-2021-01-11-1gb.img" \
                      "--config configs/beaglebone_black_debian_emmc_config" \
                      -- \
                      "-k" "'not test_update'" \


### PR DESCRIPTION
I caught this while cherry-picking #289 

* [run-tests.sh] Restore BBB eMMC convert/test
Removed by mistake at fe70255.

* Update Beaglebone EMMC Buster image.
For some reason they removed that exact image, but the other images
are still there.