### PR TITLE
2.3.x: Revert "Update to new Raspios image of 2021-02-11."

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -10,8 +10,8 @@ variables:
   MENDER_ADDON_CONNECT_VERSION: 1.0.0-build2
   # Make sure to update the link in mender-docs to the new one when changing
   # this.
-  RASPBIAN_URL: https://downloads.raspberrypi.org/raspios_lite_armhf/images/raspios_lite_armhf-2021-01-12/2021-01-11-raspios-buster-armhf-lite.zip
-  RASPBIAN_NAME: 2021-01-11-raspios-buster-armhf-lite
+  RASPBIAN_URL: http://downloads.raspberrypi.org/raspios_lite_armhf/images/raspios_lite_armhf-2020-05-28/2020-05-27-raspios-buster-lite-armhf.zip
+  RASPBIAN_NAME: 2020-05-27-raspios-buster-lite-armhf
 
   DEBIAN_FRONTEND: noninteractive
 


### PR DESCRIPTION
This reverts commit 82f9f85fdb9f876450f1dbb8603ad032a84d7864.

Seems like we are having issues with this image on RPi 4. Revert for now
and follow-up independently of the release.