### PR TITLE
MEN-4422: Optionally install Mender Configure addon

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -7,6 +7,7 @@ variables:
   MENDER_ARTIFACT_VERSION: master
   MENDER_CLIENT_VERSION: latest
   MENDER_ADDON_CONNECT_VERSION: latest
+  MENDER_ADDON_CONFIGURE_VERSION: master
   # Make sure to update the link in mender-docs to the new one when changing
   # this.
   RASPBIAN_URL: https://downloads.raspberrypi.org/raspios_lite_armhf/images/raspios_lite_armhf-2020-05-28/2020-05-27-raspios-buster-lite-armhf.zip
@@ -125,6 +126,7 @@ test:format:
   script:
     - echo "MENDER_CLIENT_VERSION=${MENDER_CLIENT_VERSION}" > versions_override_config
     - echo "MENDER_ADDON_CONNECT_VERSION=${MENDER_ADDON_CONNECT_VERSION}" >> versions_override_config
+    - echo "MENDER_ADDON_CONFIGURE_VERSION=${MENDER_ADDON_CONFIGURE_VERSION}" >> versions_override_config
     - env MENDER_ARTIFACT_NAME=${RASPBIAN_NAME}-mender-${MENDER_CLIENT_VERSION}
       ./docker-mender-convert -d ${RASPBIAN_NAME}.img
       -c configs/${RASPBERRYPI_PLATFORM}_config

--- a/configs/mender_convert_config
+++ b/configs/mender_convert_config
@@ -129,6 +129,16 @@ MENDER_ADDON_CONNECT_INSTALL="n"
 # Valid values are "latest" (default), "master" or a specific version
 MENDER_ADDON_CONNECT_VERSION="latest"
 
+# Install Mender Connect addon
+#
+MENDER_ADDON_CONFIGURE_INSTALL="n"
+
+# Mender Configure addon version
+#
+# Valid values are "latest" (default), "master" or a specific version
+#MENDER_ADDON_CONFIGURE_VERSION="latest"
+MENDER_ADDON_CONFIGURE_VERSION="master"
+
 # File storage, containing binary files, do not modify this unless you know
 # what you are doing.
 MENDER_STORAGE_URL="https://downloads.mender.io"

--- a/mender-convert-modify
+++ b/mender-convert-modify
@@ -141,6 +141,25 @@ if [ "${MENDER_ADDON_CONNECT_INSTALL}" = "y" ]; then
         work/rootfs/etc/systemd/system/multi-user.target.wants/mender-connect.service"
 fi
 
+if [ "${MENDER_ADDON_CONFIGURE_INSTALL}" = "y" ]; then
+
+    log_info "Installing Mender Configure addon"
+
+    if [ "${MENDER_ADDON_CONFIGURE_VERSION}" = "latest" ]; then
+        deb_name=$(deb_from_repo_dist_get "work/deb-packages" ${MENDER_APT_REPO_URL} ${deb_arch} "stable" "mender-configure")
+    elif [ "${MENDER_ADDON_CONFIGURE_VERSION}" = "master" ]; then
+        deb_name=$(deb_from_repo_dist_get "work/deb-packages" ${MENDER_APT_REPO_URL} ${deb_arch} "experimental" "mender-configure")
+    else
+        DEBIAN_REVISION="-1"
+        deb_name=$(deb_from_repo_pool_get "work/deb-packages" ${MENDER_APT_REPO_URL} ${deb_arch} "mender-configure" "${MENDER_ADDON_CONFIGURE_VERSION}${DEBIAN_REVISION}")
+    fi
+
+    deb_extract_package "work/deb-packages/${deb_name}" "work/rootfs/"
+
+    run_and_log_cmd "sudo mkdir -p work/rootfs/data/mender-configure"
+    run_and_log_cmd "sudo ln -sf /data/mender-configure work/rootfs/var/lib/mender-configure"
+fi
+
 if [ "${MENDER_GRUB_EFI_INTEGRATION}" == "y" ]; then
     # Check for known U-Boot problems in all files on the boot partition.
     check_for_broken_uboot_uefi_support work/boot

--- a/modules/deb.sh
+++ b/modules/deb.sh
@@ -41,7 +41,7 @@ function deb_from_repo_dist_get()  {
     local -r packages_url="${repo_url}/dists/${distribution}/${component}/binary-${architecture}/Packages"
     run_and_log_cmd "wget -Nq ${packages_url} -P /tmp"
 
-    local -r deb_package_path=$(grep Filename /tmp/Packages | grep ${package}_ | grep ${architecture} | tail -n1 | sed 's/Filename: //')
+    local -r deb_package_path=$(grep Filename /tmp/Packages | grep ${package}_ | tail -n1 | sed 's/Filename: //')
     if [ -z "${deb_package_path}" ]; then
         log_fatal "Couldn't find package ${package} in ${packages_url}"
     fi


### PR DESCRIPTION
Changelog: Support installing mender-configure addon. Not installed by
default, it can be configured using MENDER_ADDON_CONFIGURE_INSTALL and
MENDER_ADDON_CONFIGURE_VERSION variables.

Changelog: Set mender-configure version to master