### PR TITLE
The previous shell format missed the main mender-convert files ...

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -93,7 +93,8 @@ test:format:
         -kp \
         -bn \
         -w \
-        ${SCRIPTS}
+        ${SCRIPTS} \
+        mender-convert*
       # Print diff
     - git diff HEAD
       # Actual test: exits with non zero status if diff

--- a/mender-convert-extract
+++ b/mender-convert-extract
@@ -15,11 +15,11 @@
 #  limitations under the License.
 
 function trap_exit() {
-  echo "mender-convert-extract has finished. Cleaning up..."
+    echo "mender-convert-extract has finished. Cleaning up..."
 }
 
 function trap_term() {
-  true
+    true
 }
 
 trap trap_term INT TERM
@@ -35,34 +35,34 @@ source modules/probe.sh
 declare -a configs=("configs/mender_convert_config")
 
 disk_image=""
-while (( "$#" )); do
-  case "$1" in
-    -o | --overlay)
-      overlays+=("${2}")
-      shift 2
-      ;;
-    -c | --config)
-      configs+=("${2}")
-      shift 2
-      ;;
-    -d | --disk-image)
-      disk_image="${2}"
-      shift 2
-      ;;
-    *)
-      log_fatal "Sorry but the provided option is not supported: $1"
-      ;;
-  esac
+while (("$#")); do
+    case "$1" in
+        -o | --overlay)
+            overlays+=("${2}")
+            shift 2
+            ;;
+        -c | --config)
+            configs+=("${2}")
+            shift 2
+            ;;
+        -d | --disk-image)
+            disk_image="${2}"
+            shift 2
+            ;;
+        *)
+            log_fatal "Sorry but the provided option is not supported: $1"
+            ;;
+    esac
 done
 
 if [ -z "${disk_image}" ]; then
-  log_warn "Sorry, but '--disk-image' is a mandatory option"
-  log_warn "See ./mender-convert --help for more information"
-  exit 1
+    log_warn "Sorry, but '--disk-image' is a mandatory option"
+    log_warn "See ./mender-convert --help for more information"
+    exit 1
 fi
 
 if [ ! -e ${disk_image} ]; then
-  log_fatal "File not found: ${disk_image}"
+    log_fatal "File not found: ${disk_image}"
 fi
 
 # Note the use of %q formatting here. This is a bash feature to add
@@ -73,7 +73,7 @@ source modules/config.sh $(printf "%q " "${configs[@]}")
 
 MKFS_VFAT="/usr/bin/mkfs.vfat"
 if [ ! -f ${MKFS_VFAT} ]; then
-  MKFS_VFAT="/sbin/mkfs.vfat"
+    MKFS_VFAT="/sbin/mkfs.vfat"
 fi
 
 declare -a part_nrs=($(disk_get_part_nums ${disk_image}))
@@ -82,33 +82,33 @@ declare -i nr_of_parts=${#part_nrs[@]}
 log_info "Validating disk image"
 
 if [ ${nr_of_parts} -eq 0 ]; then
-  log_fatal "Sorry, but could not find any valid partitions for: ${disk_image}"
+    log_fatal "Sorry, but could not find any valid partitions for: ${disk_image}"
 fi
 
 log_info "Disk parsed successfully"
 log_info "NUMBER OF PARTS: ${nr_of_parts} TYPE: $(disk_get_part_value ${disk_image} 1 SCHEME)"
 
-for n in ${part_nrs[*]} ; do
-  part_dst_file="work/part-${n}.fs"
+for n in ${part_nrs[*]}; do
+    part_dst_file="work/part-${n}.fs"
 
-  if [ "$(disk_get_part_value ${disk_image} ${n} TYPE)" == "0x8e" ]; then
-    log_fatal "Detected an LVM volume group on disk. Unfortunately this is not yet supported"
-  fi
+    if [ "$(disk_get_part_value ${disk_image} ${n} TYPE)" == "0x8e" ]; then
+        log_fatal "Detected an LVM volume group on disk. Unfortunately this is not yet supported"
+    fi
 
-  log_info "PART ${n}: SIZE: $(disk_get_part_value ${disk_image} ${n} SIZE) TYPE: $(disk_get_part_value ${disk_image} ${n} TYPE)"
-  log_info "PART ${n}: extracting to ${part_dst_file}"
+    log_info "PART ${n}: SIZE: $(disk_get_part_value ${disk_image} ${n} SIZE) TYPE: $(disk_get_part_value ${disk_image} ${n} TYPE)"
+    log_info "PART ${n}: extracting to ${part_dst_file}"
 
-  disk_extract_part "${disk_image}" $(disk_get_part_value ${disk_image} ${n} START) \
-    $(disk_get_part_value ${disk_image} ${n} SECTORS) ${part_dst_file}
+    disk_extract_part "${disk_image}" $(disk_get_part_value ${disk_image} ${n} START) \
+        $(disk_get_part_value ${disk_image} ${n} SECTORS) ${part_dst_file}
 done
 
 # Some disk images will not have an boot partition for us to extract,
 # but we do require it be present and hence we might need to generate
 # a filesystem image here.
 if [ ${nr_of_parts} -eq 1 ]; then
-  log_info "Generating boot partition (required, does not exist in original image)"
-  run_and_log_cmd "dd if=/dev/zero of=work/boot-generated.vfat count=${MENDER_BOOT_PART_SIZE_MB} bs=1M status=none"
-  run_and_log_cmd "${MKFS_VFAT} work/boot-generated.vfat"
+    log_info "Generating boot partition (required, does not exist in original image)"
+    run_and_log_cmd "dd if=/dev/zero of=work/boot-generated.vfat count=${MENDER_BOOT_PART_SIZE_MB} bs=1M status=none"
+    run_and_log_cmd "${MKFS_VFAT} work/boot-generated.vfat"
 fi
 
 # Extract boot gap, that is the area from sector 1 until first part, and
@@ -116,13 +116,13 @@ fi
 # and we might need to keep this area intact when we generate our custom
 # image.
 if [ "${MENDER_COPY_BOOT_GAP}" == "y" ]; then
-  log_info "Extracting boot gap to work/boot-gap.bin"
-  disk_extract_part "${disk_image}" \
-    1 $(( $(disk_get_part_value ${disk_image} 1 START) - 1)) work/boot-gap.bin
+    log_info "Extracting boot gap to work/boot-gap.bin"
+    disk_extract_part "${disk_image}" \
+        1 $(($(disk_get_part_value ${disk_image} 1 START) - 1)) work/boot-gap.bin
 
-  if [ "${MENDER_GRUB_EFI_INTEGRATION}" == "y" ]; then
-    # Check for known U-Boot problems in the boot gap (probable boot loader
-    # location).
-    check_for_broken_uboot_uefi_support work/boot-gap.bin
-  fi
+    if [ "${MENDER_GRUB_EFI_INTEGRATION}" == "y" ]; then
+        # Check for known U-Boot problems in the boot gap (probable boot loader
+        # location).
+        check_for_broken_uboot_uefi_support work/boot-gap.bin
+    fi
 fi

--- a/mender-convert-modify
+++ b/mender-convert-modify
@@ -17,28 +17,28 @@
 # Default that can be overridden by providing this method in a
 # configuration file passed with '--config'
 function platform_modify() {
-  true
+    true
 }
 PLATFORM_MODIFY_HOOKS=(platform_modify)
 
 function user_local_modify() {
-  true
+    true
 }
 USER_LOCAL_MODIFY_HOOKS=(user_local_modify)
 
 function overlay_modify() {
-  true
+    true
 }
 OVERLAY_MODIFY_HOOKS=(overlay_modify)
 
 function trap_exit() {
-  echo "mender-convert-modify has finished. Cleaning up..."
-  sudo umount -f work/boot
-  sudo umount -f work/rootfs
+    echo "mender-convert-modify has finished. Cleaning up..."
+    sudo umount -f work/boot
+    sudo umount -f work/rootfs
 }
 
 function trap_term() {
-  true
+    true
 }
 
 trap trap_term INT TERM
@@ -55,24 +55,24 @@ source modules/testscfg.sh
 # The mender_convert_config is always used and provides all the defaults
 declare -a configs=("configs/mender_convert_config")
 
-while (( "$#" )); do
-  case "$1" in
-    -o | --overlay)
-      overlays+=("${2}")
-      shift 2
-      ;;
-    -c | --config)
-      configs+=("${2}")
-      shift 2
-      ;;
-    -d | --disk-image)
-      disk_image="${2}"
-      shift 2
-      ;;
-    *)
-      log_fatal "Sorry, but the provided option is not supported: $1"
-      ;;
-  esac
+while (("$#")); do
+    case "$1" in
+        -o | --overlay)
+            overlays+=("${2}")
+            shift 2
+            ;;
+        -c | --config)
+            configs+=("${2}")
+            shift 2
+            ;;
+        -d | --disk-image)
+            disk_image="${2}"
+            shift 2
+            ;;
+        *)
+            log_fatal "Sorry, but the provided option is not supported: $1"
+            ;;
+    esac
 done
 
 # Note the use of %q formatting here. This is a bash feature to add
@@ -104,12 +104,12 @@ log_info "Installing Mender client and related files"
 deb_arch=$(probe_debian_arch_name)
 
 if [ "${MENDER_CLIENT_VERSION}" = "latest" ]; then
-  deb_name=$(deb_from_repo_dist_get "work/deb-packages" ${MENDER_APT_REPO_URL} ${deb_arch} "stable" "mender-client")
+    deb_name=$(deb_from_repo_dist_get "work/deb-packages" ${MENDER_APT_REPO_URL} ${deb_arch} "stable" "mender-client")
 elif [ "${MENDER_CLIENT_VERSION}" = "master" ]; then
-  deb_name=$(deb_from_repo_dist_get "work/deb-packages" ${MENDER_APT_REPO_URL} ${deb_arch} "experimental" "mender-client")
+    deb_name=$(deb_from_repo_dist_get "work/deb-packages" ${MENDER_APT_REPO_URL} ${deb_arch} "experimental" "mender-client")
 else
-  DEBIAN_REVISION="-1"
-  deb_name=$(deb_from_repo_pool_get "work/deb-packages" ${MENDER_APT_REPO_URL} ${deb_arch} "mender-client" "${MENDER_CLIENT_VERSION}${DEBIAN_REVISION}")
+    DEBIAN_REVISION="-1"
+    deb_name=$(deb_from_repo_pool_get "work/deb-packages" ${MENDER_APT_REPO_URL} ${deb_arch} "mender-client" "${MENDER_CLIENT_VERSION}${DEBIAN_REVISION}")
 fi
 
 deb_extract_package "work/deb-packages/${deb_name}" "work/rootfs/"
@@ -118,49 +118,49 @@ deb_extract_package "work/deb-packages/${deb_name}" "work/rootfs/"
 testscfg_add "PREFERRED_VERSION_mender-client" "$(echo ${deb_name} | sed -r 's/.*_([0-9]+\.[0-9]+\.[0-9]+).*/\1/')"
 
 if [ "${MENDER_ENABLE_SYSTEMD}" == "y" ]; then
-  run_and_log_cmd "sudo ln -sf /lib/systemd/system/mender-client.service \
+    run_and_log_cmd "sudo ln -sf /lib/systemd/system/mender-client.service \
         work/rootfs/etc/systemd/system/multi-user.target.wants/mender-client.service"
 fi
 
 if [ "${MENDER_ADDON_CONNECT_INSTALL}" = "y" ]; then
 
-  log_info "Installing Mender Connect addon"
+    log_info "Installing Mender Connect addon"
 
-  if [ "${MENDER_ADDON_CONNECT_VERSION}" = "latest" ]; then
-    deb_name=$(deb_from_repo_dist_get "work/deb-packages" ${MENDER_APT_REPO_URL} ${deb_arch} "stable" "mender-connect")
-  elif [ "${MENDER_ADDON_CONNECT_VERSION}" = "master" ]; then
-    deb_name=$(deb_from_repo_dist_get "work/deb-packages" ${MENDER_APT_REPO_URL} ${deb_arch} "experimental" "mender-connect")
-  else
-    DEBIAN_REVISION="-1"
-    deb_name=$(deb_from_repo_pool_get "work/deb-packages" ${MENDER_APT_REPO_URL} ${deb_arch} "mender-connect" "${MENDER_ADDON_CONNECT_VERSION}${DEBIAN_REVISION}")
-  fi
+    if [ "${MENDER_ADDON_CONNECT_VERSION}" = "latest" ]; then
+        deb_name=$(deb_from_repo_dist_get "work/deb-packages" ${MENDER_APT_REPO_URL} ${deb_arch} "stable" "mender-connect")
+    elif [ "${MENDER_ADDON_CONNECT_VERSION}" = "master" ]; then
+        deb_name=$(deb_from_repo_dist_get "work/deb-packages" ${MENDER_APT_REPO_URL} ${deb_arch} "experimental" "mender-connect")
+    else
+        DEBIAN_REVISION="-1"
+        deb_name=$(deb_from_repo_pool_get "work/deb-packages" ${MENDER_APT_REPO_URL} ${deb_arch} "mender-connect" "${MENDER_ADDON_CONNECT_VERSION}${DEBIAN_REVISION}")
+    fi
 
-  deb_extract_package "work/deb-packages/${deb_name}" "work/rootfs/"
+    deb_extract_package "work/deb-packages/${deb_name}" "work/rootfs/"
 
-  run_and_log_cmd "sudo ln -sf /lib/systemd/system/mender-connect.service \
+    run_and_log_cmd "sudo ln -sf /lib/systemd/system/mender-connect.service \
         work/rootfs/etc/systemd/system/multi-user.target.wants/mender-connect.service"
 fi
 
 if [ "${MENDER_GRUB_EFI_INTEGRATION}" == "y" ]; then
-  # Check for known U-Boot problems in all files on the boot partition.
-  check_for_broken_uboot_uefi_support work/boot
+    # Check for known U-Boot problems in all files on the boot partition.
+    check_for_broken_uboot_uefi_support work/boot
 
-  run_and_log_cmd "wget -Nq '${MENDER_GRUBENV_URL}' -P work/"
-  run_and_log_cmd "tar xzvf work/${MENDER_GRUBENV_VERSION}.tar.gz -C work/"
+    run_and_log_cmd "wget -Nq '${MENDER_GRUBENV_URL}' -P work/"
+    run_and_log_cmd "tar xzvf work/${MENDER_GRUBENV_VERSION}.tar.gz -C work/"
 
-  if [ -z "${MENDER_GRUB_KERNEL_IMAGETYPE}" ]; then
-    kernel_imagetype=$(probe_kernel_in_boot_and_root)
-  else
-    kernel_imagetype="${MENDER_GRUB_KERNEL_IMAGETYPE}"
-  fi
+    if [ -z "${MENDER_GRUB_KERNEL_IMAGETYPE}" ]; then
+        kernel_imagetype=$(probe_kernel_in_boot_and_root)
+    else
+        kernel_imagetype="${MENDER_GRUB_KERNEL_IMAGETYPE}"
+    fi
 
-  if [ -z "${MENDER_GRUB_INITRD_IMAGETYPE}" ]; then
-    initrd_imagetype=$(probe_initrd_in_boot_and_root)
-  else
-    initrd_imagetype="${MENDER_GRUB_INITRD_IMAGETYPE}"
-  fi
+    if [ -z "${MENDER_GRUB_INITRD_IMAGETYPE}" ]; then
+        initrd_imagetype=$(probe_initrd_in_boot_and_root)
+    else
+        initrd_imagetype="${MENDER_GRUB_INITRD_IMAGETYPE}"
+    fi
 
-  cat <<- EOF > work/grub-mender-grubenv-${MENDER_GRUBENV_VERSION}/mender_grubenv_defines
+    cat <<- EOF > work/grub-mender-grubenv-${MENDER_GRUBENV_VERSION}/mender_grubenv_defines
 mender_rootfsa_part=${MENDER_ROOTFS_PART_A_NUMBER}
 mender_rootfsb_part=${MENDER_ROOTFS_PART_B_NUMBER}
 mender_grub_storage_device=${MENDER_GRUB_STORAGE_DEVICE}
@@ -168,78 +168,81 @@ kernel_imagetype=kernel
 initrd_imagetype=initrd
 EOF
 
-  run_and_log_cmd "sudo ln -s ${kernel_imagetype} work/rootfs/boot/kernel"
-  if [ "${initrd_imagetype}" != "" ]; then
-    run_and_log_cmd "sudo ln -s ${initrd_imagetype} work/rootfs/boot/initrd"
-  fi
+    run_and_log_cmd "sudo ln -s ${kernel_imagetype} work/rootfs/boot/kernel"
+    if [ "${initrd_imagetype}" != "" ]; then
+        run_and_log_cmd "sudo ln -s ${initrd_imagetype} work/rootfs/boot/initrd"
+    fi
 
-  # For partuuid support grub.cfg expects dedicated variables to be added
-  if [ "${MENDER_ENABLE_PARTUUID}" == "y" ]; then
-    rootfsa_partuuid=$(disk_get_partuuid_from_device "${root_part_a_device}")
-    rootfsb_partuuid=$(disk_get_partuuid_from_device "${root_part_b_device}")
-    log_info "Using root partition A partuuid in grubenv: $rootfsa_partuuid"
-    log_info "Using root partition B partuuid in grubenv: $rootfsb_partuuid"
-    cat <<- EOF >> work/grub-mender-grubenv-${MENDER_GRUBENV_VERSION}/mender_grubenv_defines
+    # For partuuid support grub.cfg expects dedicated variables to be added
+    if [ "${MENDER_ENABLE_PARTUUID}" == "y" ]; then
+        rootfsa_partuuid=$(disk_get_partuuid_from_device "${root_part_a_device}")
+        rootfsb_partuuid=$(disk_get_partuuid_from_device "${root_part_b_device}")
+        log_info "Using root partition A partuuid in grubenv: $rootfsa_partuuid"
+        log_info "Using root partition B partuuid in grubenv: $rootfsb_partuuid"
+        cat <<- EOF >> work/grub-mender-grubenv-${MENDER_GRUBENV_VERSION}/mender_grubenv_defines
 mender_rootfsa_uuid=${rootfsa_partuuid}
 mender_rootfsb_uuid=${rootfsb_partuuid}
 EOF
-  else
-    cat <<- EOF >> work/grub-mender-grubenv-${MENDER_GRUBENV_VERSION}/mender_grubenv_defines
+    else
+        cat <<- EOF >> work/grub-mender-grubenv-${MENDER_GRUBENV_VERSION}/mender_grubenv_defines
 mender_kernel_root_base=${MENDER_STORAGE_DEVICE_BASE}
 EOF
-  fi
+    fi
 
-  if [ -n "${MENDER_GRUB_KERNEL_BOOT_ARGS}" ]; then
-    cat <<- EOF > work/grub-mender-grubenv-${MENDER_GRUBENV_VERSION}/11_bootargs_grub.cfg
+    if [ -n "${MENDER_GRUB_KERNEL_BOOT_ARGS}" ]; then
+        cat <<- EOF > work/grub-mender-grubenv-${MENDER_GRUBENV_VERSION}/11_bootargs_grub.cfg
 set bootargs="${MENDER_GRUB_KERNEL_BOOT_ARGS}"
 EOF
-  fi
+    fi
 
-  cd work/grub-mender-grubenv-${MENDER_GRUBENV_VERSION}
-  run_and_log_cmd "make 2>&1"
-  run_and_log_cmd "sudo make DESTDIR=../ BOOT_DIR=boot install-boot-files"
-  run_and_log_cmd "sudo make DESTDIR=../rootfs install-tools"
-  cd - > /dev/null 2>&1
+    cd work/grub-mender-grubenv-${MENDER_GRUBENV_VERSION}
+    run_and_log_cmd "make 2>&1"
+    run_and_log_cmd "sudo make DESTDIR=../ BOOT_DIR=boot install-boot-files"
+    run_and_log_cmd "sudo make DESTDIR=../rootfs install-tools"
+    cd - > /dev/null 2>&1
 
-  # Remove conflicting boot files. These files do not necessarily effect the
-  # functionality, but lets get rid of them to avoid confusion.
-  #
-  # There is no Mender integration for EFI boot or systemd-boot.
-  sudo rm -rf work/boot/loader work/rootfs/boot/loader
-  sudo rm -rf work/boot/EFI/Linux
-  sudo rm -rf work/boot/EFI/systemd
-  sudo rm -rf work/boot/NvVars
-  for empty_dir in $(cd work/boot; find . -maxdepth 1 -type d -empty); do
-    sudo rmdir work/boot/$empty_dir
-  done
+    # Remove conflicting boot files. These files do not necessarily effect the
+    # functionality, but lets get rid of them to avoid confusion.
+    #
+    # There is no Mender integration for EFI boot or systemd-boot.
+    sudo rm -rf work/boot/loader work/rootfs/boot/loader
+    sudo rm -rf work/boot/EFI/Linux
+    sudo rm -rf work/boot/EFI/systemd
+    sudo rm -rf work/boot/NvVars
+    for empty_dir in $(
+                     cd work/boot
+                                   find . -maxdepth 1 -type d -empty
+    ); do
+        sudo rmdir work/boot/$empty_dir
+    done
 
-  log_info "Installing GRUB"
+    log_info "Installing GRUB"
 
-  arch=$(probe_arch)
-  efi_name=$(probe_grub_efi_name)
-  efi_target_name=$(probe_grub_efi_target_name)
+    arch=$(probe_arch)
+    efi_name=$(probe_grub_efi_name)
+    efi_target_name=$(probe_grub_efi_target_name)
 
-  log_info "GRUB EFI: ${efi_target_name}"
+    log_info "GRUB EFI: ${efi_target_name}"
 
-  run_and_log_cmd "wget -Nq ${MENDER_GRUB_BINARY_STORAGE_URL}/${arch}/${efi_name} -P work/"
-  run_and_log_cmd "wget -Nq ${MENDER_GRUB_BINARY_STORAGE_URL}/${arch}/grub-editenv -P work/"
+    run_and_log_cmd "wget -Nq ${MENDER_GRUB_BINARY_STORAGE_URL}/${arch}/${efi_name} -P work/"
+    run_and_log_cmd "wget -Nq ${MENDER_GRUB_BINARY_STORAGE_URL}/${arch}/grub-editenv -P work/"
 
-  run_and_log_cmd "sudo install -m 751 work/grub-editenv work/rootfs/usr/bin/"
+    run_and_log_cmd "sudo install -m 751 work/grub-editenv work/rootfs/usr/bin/"
 
-  run_and_log_cmd "sudo mkdir -p work/boot/EFI/BOOT"
-  run_and_log_cmd "sudo cp work/${efi_name} -P work/boot/EFI/BOOT/${efi_target_name}"
+    run_and_log_cmd "sudo mkdir -p work/boot/EFI/BOOT"
+    run_and_log_cmd "sudo cp work/${efi_name} -P work/boot/EFI/BOOT/${efi_target_name}"
 fi
 
 # Copy dtb directory to the boot partition for use by the bootloader.
 if [ -d work/rootfs/boot/dtbs ]; then
-  # Look for the first directory that has dtb files. First check the base
-  # folder, then any subfolders in versioned order.
-  for candidate in work/rootfs/boot/dtbs $(find work/rootfs/boot/dtbs/ -maxdepth 1 -type d | sort -V -r); do
-    if [ $(find $candidate -maxdepth 1 -name '*.dtb' | wc -l) -gt 0 ]; then
-      run_and_log_cmd "sudo cp -r $candidate work/boot/dtb"
-      break
-    fi
-  done
+    # Look for the first directory that has dtb files. First check the base
+    # folder, then any subfolders in versioned order.
+    for candidate in work/rootfs/boot/dtbs $(find work/rootfs/boot/dtbs/ -maxdepth 1 -type d | sort -V -r); do
+        if [ $(find $candidate -maxdepth 1 -name '*.dtb' | wc -l) -gt 0 ]; then
+            run_and_log_cmd "sudo cp -r $candidate work/boot/dtb"
+            break
+        fi
+    done
 fi
 
 run_and_log_cmd "sudo mkdir -p work/rootfs/data/mender"
@@ -259,14 +262,14 @@ run_and_log_cmd "sudo cp work/mender.conf.data work/rootfs/data/mender/mender.co
 run_and_log_cmd "sudo chmod 600 work/rootfs/data/mender/mender.conf"
 
 if [ -z "${MENDER_DEVICE_TYPE}" ]; then
-  # Observed systems who do not have this file, e.g images generated with mkosi
-  if [ -f work/rootfs/etc/hostname ]; then
-    device_type=$(cat work/rootfs/etc/hostname)
-  else
-    device_type="default"
-  fi
+    # Observed systems who do not have this file, e.g images generated with mkosi
+    if [ -f work/rootfs/etc/hostname ]; then
+        device_type=$(cat work/rootfs/etc/hostname)
+    else
+        device_type="default"
+    fi
 else
-  device_type="${MENDER_DEVICE_TYPE}"
+    device_type="${MENDER_DEVICE_TYPE}"
 fi
 
 run_and_log_cmd "echo 'device_type=${device_type}' > work/device_type"
@@ -276,8 +279,8 @@ run_and_log_cmd "echo 'artifact_name=${MENDER_ARTIFACT_NAME}' \
 
 log_info "Creating state scripts version file."
 case "${MENDER_CLIENT_VERSION}" in
-    1* ) VERSION_STRING='2';;
-    *  ) VERSION_STRING='3';;
+    1*)  VERSION_STRING='2' ;;
+    *)   VERSION_STRING='3' ;;
 esac
 run_and_log_cmd "sudo mkdir -p work/rootfs/etc/mender/scripts/"
 run_and_log_cmd "echo -n ${VERSION_STRING} | sudo tee work/rootfs/etc/mender/scripts/version"
@@ -285,24 +288,24 @@ run_and_log_cmd "echo -n ${VERSION_STRING} | sudo tee work/rootfs/etc/mender/scr
 log_info "Installing a custom /etc/fstab (see ${MENDER_CONVERT_LOG_FILE} for more info)"
 
 if [ "${MENDER_GRUB_EFI_INTEGRATION}" == "y" ]; then
-  boot_part_mountpoint="/boot/efi"
+    boot_part_mountpoint="/boot/efi"
 else
-  boot_part_mountpoint="/uboot"
+    boot_part_mountpoint="/uboot"
 fi
 
 run_and_log_cmd "sudo mkdir -p work/rootfs/${boot_part_mountpoint}"
 
 if [ "${MENDER_DATA_PART_GROWFS}" == "y" ]; then
-  MENDER_DATA_PART_FSTAB_OPTS="${MENDER_DATA_PART_FSTAB_OPTS},x-systemd.growfs"
+    MENDER_DATA_PART_FSTAB_OPTS="${MENDER_DATA_PART_FSTAB_OPTS},x-systemd.growfs"
 fi
 
 if echo ${MENDER_ROOT_PART_FSTAB_OPTS} | tr ',' '\n' | egrep -q "^ro$"; then
-  if ! echo "${MENDER_ROOT_PART_MKFS_OPTS}" | fgrep -q -- "^64bit"; then
-    log_warn "EXT4 64bits feature is known to create unstable checksums on read-only file systems, add \"-O ^64bit\" to MENDER_ROOT_PART_MKFS_OPTS to remove it"
-  fi
-  if ! echo "${MENDER_ROOT_PART_MKFS_OPTS}" | fgrep -q -- "^has_journal"; then
-    log_warn "EXT4 journal feature is known to create unstable checksums on read-only file systems, add \"-O ^has_journal\" to MENDER_ROOT_PART_MKFS_OPTS to remove it"
-  fi
+    if ! echo "${MENDER_ROOT_PART_MKFS_OPTS}" | fgrep -q -- "^64bit"; then
+        log_warn "EXT4 64bits feature is known to create unstable checksums on read-only file systems, add \"-O ^64bit\" to MENDER_ROOT_PART_MKFS_OPTS to remove it"
+    fi
+    if ! echo "${MENDER_ROOT_PART_MKFS_OPTS}" | fgrep -q -- "^has_journal"; then
+        log_warn "EXT4 journal feature is known to create unstable checksums on read-only file systems, add \"-O ^has_journal\" to MENDER_ROOT_PART_MKFS_OPTS to remove it"
+    fi
 fi
 
 log_info "Using boot partition device in fstab: $boot_part_device"
@@ -323,32 +326,32 @@ EOF"
 # inspired by: https://forums.centos.org/viewtopic.php?t=48714
 #
 if [ -f work/rootfs/etc/selinux/config ]; then
-  grep -r 'SELINUX=Enforcing' work/rootfs/etc/selinux/config || true
-  if [ $? -eq 0 ]; then
-    log_info "Selinux is in enforcing mode. Enable autorelabel"
-    touch work/rootfs/.autorelabel
-  fi
+    grep -r 'SELINUX=Enforcing' work/rootfs/etc/selinux/config || true
+    if [ $? -eq 0 ]; then
+        log_info "Selinux is in enforcing mode. Enable autorelabel"
+        touch work/rootfs/.autorelabel
+    fi
 fi
 
 log_info "Performing platform specific modifications (if any)"
 for hook in "${PLATFORM_MODIFY_HOOKS[@]}"; do
-  log_info "Running hook: $hook"
-  eval $hook
+    log_info "Running hook: $hook"
+    eval $hook
 done
 
 log_info "Performing user/local specific modifications (if any)"
 for hook in "${USER_LOCAL_MODIFY_HOOKS[@]}"; do
-  log_info "Running hook: $hook"
-  eval $hook
+    log_info "Running hook: $hook"
+    eval $hook
 done
 
 for overlay in "${overlays[@]}"; do
-  log_info "Applying rootfs overlay: ${overlay}"
-  run_and_log_cmd "sudo rsync --archive --keep-dirlinks --verbose ${overlay}/ work/rootfs/"
+    log_info "Applying rootfs overlay: ${overlay}"
+    run_and_log_cmd "sudo rsync --archive --keep-dirlinks --verbose ${overlay}/ work/rootfs/"
 done
 
 log_info "Performing overlay specific modifications (if any)"
 for hook in "${OVERLAY_MODIFY_HOOKS[@]}"; do
-  log_info "Running hook: $hook"
-  eval $hook
+    log_info "Running hook: $hook"
+    eval $hook
 done

--- a/mender-convert-package
+++ b/mender-convert-package
@@ -17,18 +17,18 @@
 # Default that can be overridden by providing this method in a
 # configuration file passed with '--config'
 function platform_package() {
-  true
+    true
 }
 PLATFORM_PACKAGE_HOOKS=(platform_package)
 
 function trap_exit() {
-  echo "mender-convert-package has finished. Cleaning up..."
-  sudo umount -f work/boot > /dev/null 2>&1 || true
-  sudo umount -f work/rootfs > /dev/null 2>&1 || true
+    echo "mender-convert-package has finished. Cleaning up..."
+    sudo umount -f work/boot > /dev/null 2>&1 || true
+    sudo umount -f work/rootfs > /dev/null 2>&1 || true
 }
 
 function trap_term() {
-  true
+    true
 }
 
 trap trap_term INT TERM
@@ -43,24 +43,24 @@ source modules/testscfg.sh
 # The mender_convert_config is always used and provides all the defaults
 declare -a configs=("configs/mender_convert_config")
 
-while (( "$#" )); do
-  case "$1" in
-    -o | --overlay)
-      overlays+=("${2}")
-      shift 2
-      ;;
-    -c | --config)
-      configs+=("${2}")
-      shift 2
-      ;;
-    -d | --disk-image)
-      disk_image="${2}"
-      shift 2
-      ;;
-    *)
-      log_fatal "Sorry but the provided option is not supported: $1"
-      ;;
-  esac
+while (("$#")); do
+    case "$1" in
+        -o | --overlay)
+            overlays+=("${2}")
+            shift 2
+            ;;
+        -c | --config)
+            configs+=("${2}")
+            shift 2
+            ;;
+        -d | --disk-image)
+            disk_image="${2}"
+            shift 2
+            ;;
+        *)
+            log_fatal "Sorry but the provided option is not supported: $1"
+            ;;
+    esac
 done
 
 # Note the use of %q formatting here. This is a bash feature to add
@@ -71,7 +71,7 @@ source modules/config.sh $(printf "%q " "${configs[@]}")
 
 PARTED="/usr/bin/parted"
 if [ ! -f ${PARTED} ]; then
-  PARTED="/sbin/parted"
+    PARTED="/sbin/parted"
 fi
 
 output_dir=work
@@ -102,46 +102,46 @@ data_part_sectors=$(disk_mb_to_sectors ${MENDER_DATA_PART_SIZE_MB})
 alignment_sectors=$((${MENDER_PARTITION_ALIGNMENT} / 512))
 
 if [ "${MENDER_GRUB_EFI_INTEGRATION}" == "y" ]; then
-  boot_part_start=${alignment_sectors}
-  overhead_sectors=$(( ${alignment_sectors} * 4 ))
+    boot_part_start=${alignment_sectors}
+    overhead_sectors=$((${alignment_sectors} * 4))
 else
-  # The two first blocks are typically reserved for U-boot environment.
-  boot_part_start=$(( ${alignment_sectors} * 3))
-  overhead_sectors=$(( ${alignment_sectors} * 6 ))
+    # The two first blocks are typically reserved for U-boot environment.
+    boot_part_start=$((${alignment_sectors} * 3))
+    overhead_sectors=$((${alignment_sectors} * 6))
 fi
 
 # Validate boot-gap.bin size, ensuring it will fit between MBR and boot_part_start
 if [ "${MENDER_COPY_BOOT_GAP}" == "y" ]; then
-  # Add one block for MBR
-  boot_gap_sectors=$(( $(stat --printf="%b" work/boot-gap.bin) + 1))
-  if [ ${boot_gap_sectors} -ge ${boot_part_start} ]; then
-    log_warn "The work/boot-gap.bin file will overwrite the boot partition"
-    log_fatal "Please increase MENDER_PARTITION_ALIGNMENT (2x will typically solve this))"
-  fi
+    # Add one block for MBR
+    boot_gap_sectors=$(($(stat --printf="%b" work/boot-gap.bin) + 1))
+    if [ ${boot_gap_sectors} -ge ${boot_part_start} ]; then
+        log_warn "The work/boot-gap.bin file will overwrite the boot partition"
+        log_fatal "Please increase MENDER_PARTITION_ALIGNMENT (2x will typically solve this))"
+    fi
 fi
 
 # Validate boot part size
 actual_boot_size=$(du --apparent-size -s --block-size=512 ${boot_part} | cut -f 1)
 if [ ${actual_boot_size} -gt ${boot_part_sectors} ]; then
-  log_warn "The allocated boot part size $(disk_sectors_to_mb ${boot_part_sectors}) MiB is too small."
-  log_warn "The actual boot part size is $(disk_sectors_to_mb ${actual_boot_size}) MiB"
-  log_warn "Will adjust MENDER_BOOT_PART_SIZE_MB automatically"
-  log_warn "Consider adjusting the configuration file to avoid this message"
-  boot_part_sectors=${actual_boot_size}
+    log_warn "The allocated boot part size $(disk_sectors_to_mb ${boot_part_sectors}) MiB is too small."
+    log_warn "The actual boot part size is $(disk_sectors_to_mb ${actual_boot_size}) MiB"
+    log_warn "Will adjust MENDER_BOOT_PART_SIZE_MB automatically"
+    log_warn "Consider adjusting the configuration file to avoid this message"
+    boot_part_sectors=${actual_boot_size}
 fi
 
 # Make sure that the boot part sector size is aligned to
 # MENDER_PARTITION_ALIGNMENT, it is possible that the boot part is extracted
 # as-is from the input image, and the input image might not have used the same
 # alignment as our configuration
-boot_part_sectors=$(disk_align_sectors ${boot_part_sectors} ${MENDER_PARTITION_ALIGNMENT} )
+boot_part_sectors=$(disk_align_sectors ${boot_part_sectors} ${MENDER_PARTITION_ALIGNMENT})
 
 # Calculate rootfs size
 rootfs_part_sectors=$(((${disk_image_total_sectors} - ${data_part_sectors} - \
-  ${boot_part_sectors} - ${overhead_sectors}) / 2))
+    ${boot_part_sectors} - ${overhead_sectors}) / 2))
 
 # Make sure rootfs size is aligned to MENDER_PARTITION_ALIGNMENT
-rootfs_part_sectors=$(disk_align_sectors ${rootfs_part_sectors} ${MENDER_PARTITION_ALIGNMENT} )
+rootfs_part_sectors=$(disk_align_sectors ${rootfs_part_sectors} ${MENDER_PARTITION_ALIGNMENT})
 
 device_type=$(cat work/rootfs/data/mender/device_type | sed 's/[^=]*=//')
 artifact_name=$(cat work/rootfs/etc/mender/artifact_info | sed 's/[^=]*=//')
@@ -151,15 +151,15 @@ temp_img_name=$(basename "$disk_image")
 
 # Check if user has chooses custom filename
 if [ -z "${DEPLOY_IMAGE_NAME}" ]; then
-# Strip the image suffix from temp_img_name and set the original image name as
-# the output image name
-  image_name="${temp_img_name%.*}"
+    # Strip the image suffix from temp_img_name and set the original image name as
+    # the output image name
+    image_name="${temp_img_name%.*}"
 
-# Add device types to the filename and replaces whitespace with + to seperate device types. 
-  image_name="${image_name}-$(sed 's| |+|g' <<< $device_type)-mender"
+    # Add device types to the filename and replaces whitespace with + to seperate device types.
+    image_name="${image_name}-$(sed 's| |+|g' <<< $device_type)-mender"
 else
-  # User has choosen custom filename in config file
-  image_name=$DEPLOY_IMAGE_NAME
+    # User has choosen custom filename in config file
+    image_name=$DEPLOY_IMAGE_NAME
 fi
 
 actual_rootfs_size=$(sudo du -s --block-size=512 work/rootfs | cut -f 1)
@@ -168,46 +168,46 @@ actual_rootfs_size=$(sudo du -s --block-size=512 work/rootfs | cut -f 1)
 image_rootfs_size_sectors=$((${IMAGE_ROOTFS_SIZE} * 2))
 
 if [ "${IMAGE_ROOTFS_SIZE}" -eq -1 ]; then
-  rootfs_image_sectors="${rootfs_part_sectors}"
+    rootfs_image_sectors="${rootfs_part_sectors}"
 elif [ "${image_rootfs_size_sectors}" -lt "${actual_rootfs_size}" ]; then
-  rootfs_image_sectors="${actual_rootfs_size}"
+    rootfs_image_sectors="${actual_rootfs_size}"
 else
-  rootfs_image_sectors="${image_rootfs_size_sectors}"
+    rootfs_image_sectors="${image_rootfs_size_sectors}"
 fi
 
 rootfs_image_sectors=$((${rootfs_image_sectors} + ${IMAGE_ROOTFS_EXTRA_SPACE} * 2))
 
 rootfs_image_sectors_overhead=$(awk -v r1="$actual_rootfs_size" "BEGIN{printf \"%.0f\", r1 * ${IMAGE_OVERHEAD_FACTOR}}")
 if [ "${rootfs_image_sectors_overhead}" -gt "${rootfs_image_sectors}" ]; then
-  rootfs_image_sectors="${rootfs_image_sectors_overhead}"
+    rootfs_image_sectors="${rootfs_image_sectors_overhead}"
 fi
 
 if [ ${rootfs_image_sectors} -gt ${rootfs_part_sectors} ]; then
-  log_warn "The calculated rootfs partition size $(disk_sectors_to_mb ${rootfs_part_sectors}) MiB is too small."
-  log_warn "The actual rootfs image size is $(disk_sectors_to_mb ${rootfs_image_sectors}) MiB"
-  log_fatal "You can try adjusting the MENDER_STORAGE_TOTAL_SIZE_MB variable to increase available space, or modify one of the variables IMAGE_ROOTFS_SIZE, IMAGE_ROOTFS_EXTRA_SPACE or IMAGE_OVERHEAD_FACTOR to reduce the size of the root filesystem."
+    log_warn "The calculated rootfs partition size $(disk_sectors_to_mb ${rootfs_part_sectors}) MiB is too small."
+    log_warn "The actual rootfs image size is $(disk_sectors_to_mb ${rootfs_image_sectors}) MiB"
+    log_fatal "You can try adjusting the MENDER_STORAGE_TOTAL_SIZE_MB variable to increase available space, or modify one of the variables IMAGE_ROOTFS_SIZE, IMAGE_ROOTFS_EXTRA_SPACE or IMAGE_OVERHEAD_FACTOR to reduce the size of the root filesystem."
 fi
 
 log_info "Rootfs filesystem size will be $(disk_sectors_to_mb ${rootfs_image_sectors}) MiB"
 
 # Extract file-system type from rootfs
 if file ${root_part} | grep -q ext4; then
-  image_fs_type="ext4"
+    image_fs_type="ext4"
 elif file ${root_part} | grep -q XFS; then
-  image_fs_type="xfs"
+    image_fs_type="xfs"
 else
-  log_warn "$(file work/${root_part})"
-  log_fatal "Could not determine root file-system type. Aborting..."
+    log_warn "$(file work/${root_part})"
+    log_fatal "Could not determine root file-system type. Aborting..."
 fi
 
 disk_create_file_system_from_folder "work/rootfs/data/" "work/data.img" \
-  "${data_part_sectors}" "${image_fs_type}"
+    "${data_part_sectors}" "${image_fs_type}"
 
 # Clear this area as it will be contained in the data.img
 sudo rm -rf work/rootfs/data/*
 
 disk_create_file_system_from_folder "work/rootfs/" "work/rootfs.img" \
-  "${rootfs_image_sectors}" "${image_fs_type}"
+    "${rootfs_image_sectors}" "${image_fs_type}"
 
 log_info "Copying root filesystem image to deploy directory"
 run_and_log_cmd "cp --sparse=always work/rootfs.img deploy/${image_name}.${image_fs_type}"
@@ -225,39 +225,39 @@ log_info "  Data partition    $(disk_sectors_to_mb ${data_part_sectors}) MiB"
 
 # Initialize sdcard image file
 run_and_log_cmd \
-  "dd if=/dev/zero of=${img_path} bs=512 count=0 seek=${disk_image_total_sectors} status=none"
+    "dd if=/dev/zero of=${img_path} bs=512 count=0 seek=${disk_image_total_sectors} status=none"
 
 # boot_part_start, is defined at the beginning of this file
-boot_part_end=$(( ${boot_part_start} + ${boot_part_sectors} - 1 ))
+boot_part_end=$((${boot_part_start} + ${boot_part_sectors} - 1))
 
-rootfsa_start=$(disk_align_sectors ${boot_part_end} ${MENDER_PARTITION_ALIGNMENT} )
-rootfsa_end=$(( ${rootfsa_start} + ${rootfs_part_sectors} - 1 ))
+rootfsa_start=$(disk_align_sectors ${boot_part_end} ${MENDER_PARTITION_ALIGNMENT})
+rootfsa_end=$((${rootfsa_start} + ${rootfs_part_sectors} - 1))
 
-rootfsb_start=$(disk_align_sectors ${rootfsa_end} ${MENDER_PARTITION_ALIGNMENT} )
-rootfsb_end=$(( ${rootfsb_start} + ${rootfs_part_sectors} - 1 ))
+rootfsb_start=$(disk_align_sectors ${rootfsa_end} ${MENDER_PARTITION_ALIGNMENT})
+rootfsb_end=$((${rootfsb_start} + ${rootfs_part_sectors} - 1))
 
-data_start=$(disk_align_sectors ${rootfsb_end} ${MENDER_PARTITION_ALIGNMENT} )
-data_end=$(( ${data_start} + ${data_part_sectors} - 1 ))
+data_start=$(disk_align_sectors ${rootfsb_end} ${MENDER_PARTITION_ALIGNMENT})
+data_end=$((${data_start} + ${data_part_sectors} - 1))
 
 if [ -n "${MENDER_PARTITION_SCHEME}" ]; then
-  # Force partition scheme to the one from configs
-  partition_scheme="${MENDER_PARTITION_SCHEME}"
-  log_info "Forcing partition scheme defined by MENDER_PARTITION_SCHEME to: ${partition_scheme}"
+    # Force partition scheme to the one from configs
+    partition_scheme="${MENDER_PARTITION_SCHEME}"
+    log_info "Forcing partition scheme defined by MENDER_PARTITION_SCHEME to: ${partition_scheme}"
 else
-  # By default use the partition scheme from the input image
-  partition_scheme=$(disk_get_part_value ${disk_image} 1 SCHEME)
-  log_info "Using input diskimage partition scheme (${partition_scheme})"
+    # By default use the partition scheme from the input image
+    partition_scheme=$(disk_get_part_value ${disk_image} 1 SCHEME)
+    log_info "Using input diskimage partition scheme (${partition_scheme})"
 fi
 
 # Create partition table.
 if [ "${partition_scheme}" == "gpt" ]; then
-  log_info "Writing GPT partition table"
-  run_and_log_cmd "${PARTED} -s ${img_path} mklabel gpt"
-  run_and_log_cmd "${PARTED} -s ${img_path} unit s mkpart ESP fat32 ${boot_part_start} ${boot_part_end}"
+    log_info "Writing GPT partition table"
+    run_and_log_cmd "${PARTED} -s ${img_path} mklabel gpt"
+    run_and_log_cmd "${PARTED} -s ${img_path} unit s mkpart ESP fat32 ${boot_part_start} ${boot_part_end}"
 else
-  log_info "Writing DOS (MBR) partition table"
-  run_and_log_cmd "${PARTED} -s ${img_path} mklabel msdos"
-  run_and_log_cmd "${PARTED} -s ${img_path} unit s mkpart primary fat32 ${boot_part_start} ${boot_part_end}"
+    log_info "Writing DOS (MBR) partition table"
+    run_and_log_cmd "${PARTED} -s ${img_path} mklabel msdos"
+    run_and_log_cmd "${PARTED} -s ${img_path} unit s mkpart primary fat32 ${boot_part_start} ${boot_part_end}"
 fi
 run_and_log_cmd "${PARTED} -s ${img_path} set 1 boot on"
 run_and_log_cmd "${PARTED} -s ${img_path} -- unit s mkpart primary ext4 ${rootfsa_start} ${rootfsa_end}"
@@ -267,29 +267,29 @@ run_and_log_cmd "${PARTED} -s ${img_path} print"
 
 # Update partition uuids if required
 if [ "${MENDER_ENABLE_PARTUUID}" == "y" ]; then
-  boot_partuuid=$(disk_get_partuuid_from_device "${boot_part_device}")
-  rootfsa_partuuid=$(disk_get_partuuid_from_device "${root_part_a_device}")
-  rootfsb_partuuid=$(disk_get_partuuid_from_device "${root_part_b_device}")
-  data_partuuid=$(disk_get_partuuid_from_device "${data_part_device}")
+    boot_partuuid=$(disk_get_partuuid_from_device "${boot_part_device}")
+    rootfsa_partuuid=$(disk_get_partuuid_from_device "${root_part_a_device}")
+    rootfsb_partuuid=$(disk_get_partuuid_from_device "${root_part_b_device}")
+    data_partuuid=$(disk_get_partuuid_from_device "${data_part_device}")
 
-  if [ "${partition_scheme}" == "gpt" ]; then
-    log_info "Updating GPT partition uuids in image: '${img_path}'"
-    run_and_log_cmd "sgdisk -u ${MENDER_BOOT_PART_NUMBER}:${boot_partuuid} '${img_path}'"
-    run_and_log_cmd "sgdisk -u ${MENDER_ROOTFS_PART_A_NUMBER}:${rootfsa_partuuid} '${img_path}'"
-    run_and_log_cmd "sgdisk -u ${MENDER_ROOTFS_PART_B_NUMBER}:${rootfsb_partuuid} '${img_path}'"
-    run_and_log_cmd "sgdisk -u ${MENDER_DATA_PART_NUMBER}:${data_partuuid} '${img_path}'"
-  else
-    diskid=$(disk_get_partuuid_dos_diskid_from_device "${root_part_a_device}")
-    log_info "Updating MBR disk identifier for partition uuid support to: '0x${diskid}'"
-    run_and_log_cmd "xxd -r -p <<< '${diskid}' | LC_ALL=C rev | dd of='${img_path}' bs=1 seek=440 count=4 conv=notrunc"
-  fi
+    if [ "${partition_scheme}" == "gpt" ]; then
+        log_info "Updating GPT partition uuids in image: '${img_path}'"
+        run_and_log_cmd "sgdisk -u ${MENDER_BOOT_PART_NUMBER}:${boot_partuuid} '${img_path}'"
+        run_and_log_cmd "sgdisk -u ${MENDER_ROOTFS_PART_A_NUMBER}:${rootfsa_partuuid} '${img_path}'"
+        run_and_log_cmd "sgdisk -u ${MENDER_ROOTFS_PART_B_NUMBER}:${rootfsb_partuuid} '${img_path}'"
+        run_and_log_cmd "sgdisk -u ${MENDER_DATA_PART_NUMBER}:${data_partuuid} '${img_path}'"
+    else
+        diskid=$(disk_get_partuuid_dos_diskid_from_device "${root_part_a_device}")
+        log_info "Updating MBR disk identifier for partition uuid support to: '0x${diskid}'"
+        run_and_log_cmd "xxd -r -p <<< '${diskid}' | LC_ALL=C rev | dd of='${img_path}' bs=1 seek=440 count=4 conv=notrunc"
+    fi
 
 fi
 
 # Write boot-gap
 if [ "${MENDER_COPY_BOOT_GAP}" == "y" ]; then
-  log_info "Writing boot gap of size: ${boot_part_sectors} (sectors)"
-  disk_write_at_offset "${output_dir}/boot-gap.bin" "${img_path}" "1"
+    log_info "Writing boot gap of size: ${boot_part_sectors} (sectors)"
+    disk_write_at_offset "${output_dir}/boot-gap.bin" "${img_path}" "1"
 fi
 
 # Unmount filesystem image files
@@ -308,39 +308,39 @@ disk_write_at_offset "${output_dir}/data.img" "${img_path}" "${data_start}"
 
 log_info "Performing platform specific package operations (if any)"
 for hook in "${PLATFORM_PACKAGE_HOOKS[@]}"; do
-  log_info "Running hook: $hook"
-  eval $hook
+    log_info "Running hook: $hook"
+    eval $hook
 done
 
 # Create bmap index
 if [ "${MENDER_USE_BMAP}" == "y" ]; then
-  BMAP_TOOL="/usr/bin/bmaptool"
-  if [ ! -e "${BMAP_TOOL}" ]; then
-    log_error "You have enabled the MENDER_USE_BMAP option, but we could not find the required 'bmaptool'"
-    log_fatal "You can install 'bmaptool' with: apt-get install bmap-tools (on Debian based distributions)"
-  fi
-  run_and_log_cmd "${BMAP_TOOL} create ${img_path} > ${img_path}.bmap"
+    BMAP_TOOL="/usr/bin/bmaptool"
+    if [ ! -e "${BMAP_TOOL}" ]; then
+        log_error "You have enabled the MENDER_USE_BMAP option, but we could not find the required 'bmaptool'"
+        log_fatal "You can install 'bmaptool' with: apt-get install bmap-tools (on Debian based distributions)"
+    fi
+    run_and_log_cmd "${BMAP_TOOL} create ${img_path} > ${img_path}.bmap"
 fi
 
 case "${MENDER_COMPRESS_DISK_IMAGE}" in
-  gzip)
-    log_info "Compressing ${img_path}.gz"
-    run_and_log_cmd "pigz --best --force ${img_path}"
-    ;;
-  zip)
-    log_info "Compressing ${img_path}.zip"
-    zip -9 "${img_path}.zip" "${img_path}"
-    ;;
-  lzma)
-    log_info "Compressing ${img_path}.xz"
-    run_and_log_cmd "pxz --best --force ${img_path}"
-    ;;
-  none)
-    :
-    ;;
-  *)
-    log_fatal "Unknown MENDER_COMPRESS_DISK_IMAGE value: ${MENDER_COMPRESS_DISK_IMAGE}"
-    ;;
+    gzip)
+        log_info "Compressing ${img_path}.gz"
+        run_and_log_cmd "pigz --best --force ${img_path}"
+        ;;
+    zip)
+        log_info "Compressing ${img_path}.zip"
+        zip -9 "${img_path}.zip" "${img_path}"
+        ;;
+    lzma)
+        log_info "Compressing ${img_path}.xz"
+        run_and_log_cmd "pxz --best --force ${img_path}"
+        ;;
+    none)
+        :
+        ;;
+    *)
+        log_fatal "Unknown MENDER_COMPRESS_DISK_IMAGE value: ${MENDER_COMPRESS_DISK_IMAGE}"
+        ;;
 esac
 
 log_info "Conversion has completed! \o/"
@@ -348,15 +348,15 @@ log_info "Conversion has completed! \o/"
 ##################### Create configuration file for tests ######################
 
 if [ "${MENDER_GRUB_EFI_INTEGRATION}" == "y" ]; then
-  boot_part_mountpoint="/boot/efi"
+    boot_part_mountpoint="/boot/efi"
 
-  # This is the name of the MENDER_FEATURES in Yocto
-  bootloader_feature="mender-grub"
+    # This is the name of the MENDER_FEATURES in Yocto
+    bootloader_feature="mender-grub"
 else
-  boot_part_mountpoint="/uboot"
+    boot_part_mountpoint="/uboot"
 
-  # This is the name of the MENDER_FEATURES in Yocto
-  bootloader_feature="mender-uboot"
+    # This is the name of the MENDER_FEATURES in Yocto
+    bootloader_feature="mender-uboot"
 fi
 mender_features="${bootloader_feature} mender-convert"
 
@@ -368,7 +368,7 @@ testscfg_add "MENDER_BOOT_PART_MOUNT_LOCATION" "${boot_part_mountpoint}"
 testscfg_add "MENDER_BOOT_PART_SIZE_MB" "$(disk_sectors_to_mb ${boot_part_sectors})"
 testscfg_add "MENDER_DATA_PART_SIZE_MB" "${MENDER_DATA_PART_SIZE_MB}"
 testscfg_add "MENDER_DEVICE_TYPE" "${device_type}"
-testscfg_add "MENDER_PARTITIONING_OVERHEAD_KB" "$(( (${overhead_sectors} * 512) / 1024 ))"
+testscfg_add "MENDER_PARTITIONING_OVERHEAD_KB" "$(((${overhead_sectors} * 512) / 1024))"
 testscfg_add "MENDER_PARTITION_ALIGNMENT" "${MENDER_PARTITION_ALIGNMENT}"
 testscfg_add "MENDER_STORAGE_TOTAL_SIZE_MB" "${MENDER_STORAGE_TOTAL_SIZE_MB}"
 testscfg_add "MENDER_UBOOT_ENV_STORAGE_DEVICE_OFFSET" "12582912"
@@ -379,7 +379,7 @@ testscfg_add "MENDER_MACHINE" "${device_type}"
 
 # Outputting device base only relevant for some configurations
 if [ "${MENDER_ENABLE_PARTUUID}" != "y" ]; then
-  testscfg_add "MENDER_STORAGE_DEVICE_BASE" "${MENDER_STORAGE_DEVICE_BASE}"
+    testscfg_add "MENDER_STORAGE_DEVICE_BASE" "${MENDER_STORAGE_DEVICE_BASE}"
 fi
 
 # Something that the tests expect to be defined (originally from Yocto)


### PR DESCRIPTION
I'm sorry

This should fix
* format _mender-convert*_ files in root
* CI for verifying this
Does not
* format docker-build-script.sh and docker-build. Should this be added?