### PR TITLE
[overlay-demo-server.sh] Remove ServerURL from mender-connect.conf

### DIFF
--- a/scripts/bootstrap-rootfs-overlay-demo-server.sh
+++ b/scripts/bootstrap-rootfs-overlay-demo-server.sh
@@ -71,7 +71,6 @@ chmod 600 ${output_dir}/etc/mender/mender.conf
 
 cat <<- EOF > ${output_dir}/etc/mender/mender-connect.conf
 {
-  "ServerURL": "https://docker.mender.io",
   "ShellCommand": "/bin/sh",
   "User": "root"
 }


### PR DESCRIPTION
This parameter is not necessary, the ServerURL is passed from
mender-client to mender-connect via DBus API.