### PR TITLE
MEN-4117: Support headless configuration on Raspberry Pi

### DIFF
--- a/configs/mender_convert_config
+++ b/configs/mender_convert_config
@@ -230,6 +230,10 @@ IMAGE_ROOTFS_EXTRA_SPACE="0"
 # why it is missing a "MENDER_" prefix.
 IMAGE_OVERHEAD_FACTOR="1.5"
 
+# User specified mount point for the boot partition. If empty (default), is mounted
+# at '/boot/efi' for UEFI integration, or at '/uboot' for other cases (U-boot)
+MENDER_BOOT_PART_MOUNT_LOCATION=""
+
 source configs/mender_grub_config
 
 # Function to create Mender Artifact

--- a/configs/raspberrypi_config
+++ b/configs/raspberrypi_config
@@ -4,6 +4,9 @@
 # Raspberry Pi does not support GRUB bootloader integration, fallback to U-boot.
 MENDER_GRUB_EFI_INTEGRATION=n
 
+# Use same boot point that upstream to support Headless configuration
+MENDER_BOOT_PART_MOUNT_LOCATION="/boot"
+
 # Nothing to copy
 MENDER_COPY_BOOT_GAP=n
 

--- a/mender-convert-modify
+++ b/mender-convert-modify
@@ -306,10 +306,14 @@ run_and_log_cmd "echo -n ${VERSION_STRING} | sudo tee work/rootfs/etc/mender/scr
 
 log_info "Installing a custom /etc/fstab (see ${MENDER_CONVERT_LOG_FILE} for more info)"
 
-if [ "${MENDER_GRUB_EFI_INTEGRATION}" == "y" ]; then
-    boot_part_mountpoint="/boot/efi"
+if [ -n "${MENDER_BOOT_PART_MOUNT_LOCATION}" ]; then
+    boot_part_mountpoint="${MENDER_BOOT_PART_MOUNT_LOCATION}"
 else
-    boot_part_mountpoint="/uboot"
+    if [ "${MENDER_GRUB_EFI_INTEGRATION}" == "y" ]; then
+        boot_part_mountpoint="/boot/efi"
+    else
+        boot_part_mountpoint="/uboot"
+    fi
 fi
 
 run_and_log_cmd "sudo mkdir -p work/rootfs/${boot_part_mountpoint}"

--- a/mender-convert-package
+++ b/mender-convert-package
@@ -347,14 +347,20 @@ log_info "Conversion has completed! \o/"
 
 ##################### Create configuration file for tests ######################
 
-if [ "${MENDER_GRUB_EFI_INTEGRATION}" == "y" ]; then
-    boot_part_mountpoint="/boot/efi"
+if [ -n "${MENDER_BOOT_PART_MOUNT_LOCATION}" ]; then
+    boot_part_mountpoint="${MENDER_BOOT_PART_MOUNT_LOCATION}"
+else
+    if [ "${MENDER_GRUB_EFI_INTEGRATION}" == "y" ]; then
+        boot_part_mountpoint="/boot/efi"
+    else
+        boot_part_mountpoint="/uboot"
+    fi
+fi
 
+if [ "${MENDER_GRUB_EFI_INTEGRATION}" == "y" ]; then
     # This is the name of the MENDER_FEATURES in Yocto
     bootloader_feature="mender-grub"
 else
-    boot_part_mountpoint="/uboot"
-
     # This is the name of the MENDER_FEATURES in Yocto
     bootloader_feature="mender-uboot"
 fi


### PR DESCRIPTION
By introducing `MENDER_BOOT_PART_MOUNT_LOCATION` config parameter and
setting it to `/boot` for Raspberry Pi

Changelog: New config parameter `MENDER_BOOT_PART_MOUNT_LOCATION` to
specify the mount point for the boot partition. Empty (default) will
result in `/boot/efi` when UEFI boot is supported, `/uboot` otherwise.

Changelog: Set `MENDER_BOOT_PART_MOUNT_LOCATION=/boot` on Raspberry Pi
configuration to support headless configuration.