### PR TITLE
MEN-4117: Support headless configuration on Raspberry Pi

### DIFF
--- a/configs/raspberrypi_config
+++ b/configs/raspberrypi_config
@@ -91,6 +91,13 @@ function platform_modify() {
     run_and_log_cmd "sudo ln -fs /uboot/overlays work/rootfs/boot/overlays"
     run_and_log_cmd "sudo ln -fs /uboot/$CMDLINE work/rootfs/boot/$CMDLINE"
 
+    # Raspberry Pi headless configuration expects boot partition to be mounted
+    # at /boot, so replace these services with /uboot
+    run_and_log_cmd "find work/rootfs/lib/ -type f -name *.service | xargs sed -i.bak 's|/boot/|/uboot/|g'"
+    log_debug "Diff from modified service files:\n$(find work/rootfs/lib/ -type f -name '*.service' | xargs -I@ bash -c 'diff -u @.bak @')"
+    run_and_log_cmd "find work/rootfs/lib/ -type f -name *.service.bak | xargs rm"
+    log_info "Certain service files have been changed to align with our /uboot boot partition mount point. See convert.log for more information"
+
     run_and_log_cmd "sudo install -m 755 work/rpi/binaries/fw_printenv work/rootfs/sbin/fw_printenv"
     run_and_log_cmd "sudo ln -fs /sbin/fw_printenv work/rootfs/sbin/fw_setenv"
 

--- a/docker-mender-convert
+++ b/docker-mender-convert
@@ -45,3 +45,5 @@ docker run \
   $IMAGE_NAME "$@"
 
 [ $? -eq 0 ] && rmdir ${WORK_DIR}
+
+echo "Log file available at: logs/${LOG_FILE}"


### PR DESCRIPTION
By editing upstream systemd services to expect boot partition in /uboot
instead of /boot

Changelog: raspberrypi_config: Modify headless configuration services to
expect boot partition in /uboot instead of /boot.