### PR TITLE
Revert "MEN-4256: Remove /etc/mender/artifact_info from RPi pre-conve…

### DIFF
--- a/configs/images/raspberrypi_raspbian_config
+++ b/configs/images/raspberrypi_raspbian_config
@@ -57,13 +57,3 @@ function create_mender_configure_state_folder_data_partition() {
 }
 
 PLATFORM_MODIFY_HOOKS+=(create_mender_configure_state_folder_data_partition)
-
-#
-# Remove /etc/mender/artifact_info from image, expected to be populated at setup time
-#
-function remove_artifact_info() {
-    log_info "Removing /etc/mender/artifact_info"
-    run_and_log_cmd "rm work/rootfs/etc/mender/artifact_info"
-}
-
-USER_LOCAL_MODIFY_HOOKS+=(remove_artifact_info)

--- a/mender-convert-package
+++ b/mender-convert-package
@@ -144,6 +144,7 @@ rootfs_part_sectors=$(((${disk_image_total_sectors} - ${data_part_sectors} - \
 rootfs_part_sectors=$(disk_align_sectors ${rootfs_part_sectors} ${MENDER_PARTITION_ALIGNMENT})
 
 device_type=$(cat work/rootfs/data/mender/device_type | sed 's/[^=]*=//')
+artifact_name=$(cat work/rootfs/etc/mender/artifact_info | sed 's/[^=]*=//')
 
 # Get the name from the input disk_image
 temp_img_name=$(basename "$disk_image")
@@ -211,7 +212,7 @@ disk_create_file_system_from_folder "work/rootfs/" "work/rootfs.img" \
 log_info "Copying root filesystem image to deploy directory"
 run_and_log_cmd "cp --sparse=always work/rootfs.img deploy/${image_name}.${image_fs_type}"
 
-mender_create_artifact "${device_type}" "${MENDER_ARTIFACT_NAME}" "${image_name}"
+mender_create_artifact "${device_type}" "${artifact_name}" "${image_name}"
 
 log_info "Creating Mender compatible disk-image"
 
@@ -371,7 +372,7 @@ testscfg_add "MENDER_PARTITIONING_OVERHEAD_KB" "$(((${overhead_sectors} * 512) /
 testscfg_add "MENDER_PARTITION_ALIGNMENT" "${MENDER_PARTITION_ALIGNMENT}"
 testscfg_add "MENDER_STORAGE_TOTAL_SIZE_MB" "${MENDER_STORAGE_TOTAL_SIZE_MB}"
 testscfg_add "MENDER_UBOOT_ENV_STORAGE_DEVICE_OFFSET" "12582912"
-testscfg_add "MENDER_ARTIFACT_NAME" "${MENDER_ARTIFACT_NAME}"
+testscfg_add "MENDER_ARTIFACT_NAME" "${artifact_name}"
 testscfg_add "MENDER_FEATURES" "${mender_features}"
 testscfg_add "DEPLOY_DIR_IMAGE" "${PWD}/deploy"
 testscfg_add "MENDER_MACHINE" "${device_type}"


### PR DESCRIPTION
…rted image"

This reverts commit 417b82ae763243b33726174fb75be236f4ce91cd.

Without this file, Mender can not be used out of the box.

Changelog: None

Signed-off-by: Kristian Amlie <kristian.amlie@northern.tech>
