### PR TITLE
Remove tinker.js monitoring from the Github action flow

### DIFF
--- a/.github/workflows/automatically-update-test-links.yml
+++ b/.github/workflows/automatically-update-test-links.yml
@@ -16,7 +16,6 @@ jobs:
             node monitor-bb.js
             node monitor-bb-sd.js
             node monitor-rpi.js
-            node monitor-tinker.js
             node monitor-ub-server.js
         working-directory: scripts/linkbot
 


### PR DESCRIPTION
Changelog: None
Signed-off-by: Ole Petter <ole.orhagen@northern.tech>
