### PR TITLE
MEN-4256 Do not install the client by default on Prebuilt RPi images

### DIFF
--- a/configs/images/raspberrypi_raspbian_config
+++ b/configs/images/raspberrypi_raspbian_config
@@ -13,6 +13,9 @@ IMAGE_OVERHEAD_FACTOR=1.0
 # Best compression there is!
 MENDER_COMPRESS_DISK_IMAGE=lzma
 
+# MEN-4256: Do not install the mender-client by default in our images
+MENDER_CLIENT_INSTALL="n"
+
 #
 # Resize the data partition to fill the remaining space, using parted, with systemd
 #

--- a/configs/mender_convert_config
+++ b/configs/mender_convert_config
@@ -113,6 +113,10 @@ MENDER_DATA_PART_SIZE_MB="128"
 # Default is 8MB
 MENDER_PARTITION_ALIGNMENT="8388608"
 
+# Install Mender client
+#
+MENDER_CLIENT_INSTALL="y"
+
 # Mender client version
 #
 # This is used to fetch the correct binaries

--- a/docker-mender-convert
+++ b/docker-mender-convert
@@ -44,6 +44,10 @@ docker run \
   --env MENDER_CONVERT_LOG_FILE=logs/${LOG_FILE} \
   $IMAGE_NAME "$@"
 
-[ $? -eq 0 ] && rmdir ${WORK_DIR}
+exit_code=$?
+
+[ ${exit_code} -eq 0 ] && rmdir ${WORK_DIR}
 
 echo "Log file available at: logs/${LOG_FILE}"
+
+exit ${exit_code}

--- a/mender-convert-modify
+++ b/mender-convert-modify
@@ -103,13 +103,19 @@ log_info "Installing Mender client and related files"
 
 deb_arch=$(probe_debian_arch_name)
 
-if [ "${MENDER_CLIENT_VERSION}" = "latest" ]; then
-    deb_name=$(deb_from_repo_dist_get "work/deb-packages" ${MENDER_APT_REPO_URL} ${deb_arch} "stable" "mender-client")
-elif [ "${MENDER_CLIENT_VERSION}" = "master" ]; then
-    deb_name=$(deb_from_repo_dist_get "work/deb-packages" ${MENDER_APT_REPO_URL} ${deb_arch} "experimental" "mender-client")
-else
-    DEBIAN_REVISION="-1"
-    deb_name=$(deb_from_repo_pool_get "work/deb-packages" ${MENDER_APT_REPO_URL} ${deb_arch} "mender-client" "${MENDER_CLIENT_VERSION}${DEBIAN_REVISION}")
+if [ "${MENDER_CLIENT_INSTALL}" = "y" ]; then
+
+    log_info "Installing Mender Client version ${MENDER_CLIENT_VERSION}"
+
+    if [ "${MENDER_CLIENT_VERSION}" = "latest" ]; then
+        deb_name=$(deb_from_repo_dist_get "work/deb-packages" ${MENDER_APT_REPO_URL} ${deb_arch} "stable" "mender-client")
+    elif [ "${MENDER_CLIENT_VERSION}" = "master" ]; then
+        deb_name=$(deb_from_repo_dist_get "work/deb-packages" ${MENDER_APT_REPO_URL} ${deb_arch} "experimental" "mender-client")
+    else
+        DEBIAN_REVISION="-1"
+        deb_name=$(deb_from_repo_pool_get "work/deb-packages" ${MENDER_APT_REPO_URL} ${deb_arch} "mender-client" "${MENDER_CLIENT_VERSION}${DEBIAN_REVISION}")
+    fi
+
 fi
 
 deb_extract_package "work/deb-packages/${deb_name}" "work/rootfs/"

--- a/mender-convert-modify
+++ b/mender-convert-modify
@@ -116,12 +116,12 @@ if [ "${MENDER_CLIENT_INSTALL}" = "y" ]; then
         deb_name=$(deb_from_repo_pool_get "work/deb-packages" ${MENDER_APT_REPO_URL} ${deb_arch} "mender-client" "${MENDER_CLIENT_VERSION}${DEBIAN_REVISION}")
     fi
 
+    deb_extract_package "work/deb-packages/${deb_name}" "work/rootfs/"
+
+    # Save installed client version for tests in Yocto variable format
+    testscfg_add "PREFERRED_VERSION_mender-client" "$(echo ${deb_name} | sed -r 's/.*_([0-9]+\.[0-9]+\.[0-9]+).*/\1/')"
+
 fi
-
-deb_extract_package "work/deb-packages/${deb_name}" "work/rootfs/"
-
-# Save installed client version for tests in Yocto variable format
-testscfg_add "PREFERRED_VERSION_mender-client" "$(echo ${deb_name} | sed -r 's/.*_([0-9]+\.[0-9]+\.[0-9]+).*/\1/')"
 
 if [ "${MENDER_ENABLE_SYSTEMD}" == "y" ]; then
     run_and_log_cmd "sudo ln -sf /lib/systemd/system/mender-client.service \

--- a/mender-convert-modify
+++ b/mender-convert-modify
@@ -303,8 +303,11 @@ fi
 
 run_and_log_cmd "echo 'device_type=${device_type}' > work/device_type"
 run_and_log_cmd "sudo install -m 0444 work/device_type work/rootfs/data/mender/"
-run_and_log_cmd "echo 'artifact_name=${MENDER_ARTIFACT_NAME}' \
-  | sudo tee work/rootfs/etc/mender/artifact_info"
+
+if [ "${MENDER_CLIENT_INSTALL}" = "y" ]; then
+    run_and_log_cmd "echo 'artifact_name=${MENDER_ARTIFACT_NAME}' \
+                     | sudo tee work/rootfs/etc/mender/artifact_info"
+fi
 
 log_info "Creating state scripts version file."
 case "${MENDER_CLIENT_VERSION}" in

--- a/mender-convert-package
+++ b/mender-convert-package
@@ -349,6 +349,8 @@ log_info "Conversion has completed! \o/"
 
 ##################### Create configuration file for tests ######################
 
+mender_features="mender-convert"
+
 if [ "${MENDER_GRUB_EFI_INTEGRATION}" == "y" ]; then
     boot_part_mountpoint="/boot/efi"
 
@@ -360,7 +362,11 @@ else
     # This is the name of the MENDER_FEATURES in Yocto
     bootloader_feature="mender-uboot"
 fi
-mender_features="${bootloader_feature} mender-convert"
+mender_features="${mender_features} ${bootloader_feature}"
+
+if [ "${MENDER_CLIENT_INSTALL}" = "y" ]; then
+    mender_features="${mender_features} mender-client-install"
+fi
 
 testscfg_add "MENDER_BOOT_PART" "${boot_part_device}"
 testscfg_add "MENDER_ROOTFS_PART_A" "${root_part_a_device}"

--- a/mender-convert-package
+++ b/mender-convert-package
@@ -148,7 +148,7 @@ device_type=$(cat work/rootfs/data/mender/device_type | sed 's/[^=]*=//')
 # Get the name from the input disk_image
 temp_img_name=$(basename "$disk_image")
 
-# Check if user has chooses custom filename
+# Check if user has chosen custom filename
 if [ -z "${DEPLOY_IMAGE_NAME}" ]; then
     # Strip the image suffix from temp_img_name and set the original image name as
     # the output image name

--- a/mender-convert-package
+++ b/mender-convert-package
@@ -211,6 +211,9 @@ disk_create_file_system_from_folder "work/rootfs/" "work/rootfs.img" \
 log_info "Copying root filesystem image to deploy directory"
 run_and_log_cmd "cp --sparse=always work/rootfs.img deploy/${image_name}.${image_fs_type}"
 
+if [ "${MENDER_CLIENT_INSTALL}" != "y" ]; then
+    log_warn "Generating Artifact with no Mender client in it; not suitable for deployment"
+fi
 mender_create_artifact "${device_type}" "${MENDER_ARTIFACT_NAME}" "${image_name}"
 
 log_info "Creating Mender compatible disk-image"

--- a/mender-convert-package
+++ b/mender-convert-package
@@ -144,7 +144,6 @@ rootfs_part_sectors=$(((${disk_image_total_sectors} - ${data_part_sectors} - \
 rootfs_part_sectors=$(disk_align_sectors ${rootfs_part_sectors} ${MENDER_PARTITION_ALIGNMENT})
 
 device_type=$(cat work/rootfs/data/mender/device_type | sed 's/[^=]*=//')
-artifact_name=$(cat work/rootfs/etc/mender/artifact_info | sed 's/[^=]*=//')
 
 # Get the name from the input disk_image
 temp_img_name=$(basename "$disk_image")
@@ -212,7 +211,7 @@ disk_create_file_system_from_folder "work/rootfs/" "work/rootfs.img" \
 log_info "Copying root filesystem image to deploy directory"
 run_and_log_cmd "cp --sparse=always work/rootfs.img deploy/${image_name}.${image_fs_type}"
 
-mender_create_artifact "${device_type}" "${artifact_name}" "${image_name}"
+mender_create_artifact "${device_type}" "${MENDER_ARTIFACT_NAME}" "${image_name}"
 
 log_info "Creating Mender compatible disk-image"
 
@@ -372,7 +371,7 @@ testscfg_add "MENDER_PARTITIONING_OVERHEAD_KB" "$(((${overhead_sectors} * 512) /
 testscfg_add "MENDER_PARTITION_ALIGNMENT" "${MENDER_PARTITION_ALIGNMENT}"
 testscfg_add "MENDER_STORAGE_TOTAL_SIZE_MB" "${MENDER_STORAGE_TOTAL_SIZE_MB}"
 testscfg_add "MENDER_UBOOT_ENV_STORAGE_DEVICE_OFFSET" "12582912"
-testscfg_add "MENDER_ARTIFACT_NAME" "${artifact_name}"
+testscfg_add "MENDER_ARTIFACT_NAME" "${MENDER_ARTIFACT_NAME}"
 testscfg_add "MENDER_FEATURES" "${mender_features}"
 testscfg_add "DEPLOY_DIR_IMAGE" "${PWD}/deploy"
 testscfg_add "MENDER_MACHINE" "${device_type}"


### PR DESCRIPTION
This adds the:

* `MENDER_CLIENT_INSTALL` option, to allow an image to come without the
mender-client installed by default.

The option is on by default, but turned off for the custom image configuration
we use for building the images we provide as a part of our documentation onboarding.

Changelog: Add an option: 'MENDER_CLIENT_INSTALL={y,n}', to allow a converted
image to come without the Mender client installed by default.

Signed-off-by: Ole Petter <ole.orhagen@northern.tech>


# External Contributor Checklist

🚨 Please review the [guidelines for contributing](https://github.com/mendersoftware/mender/blob/master/CONTRIBUTING.md) to this repository.

- [x] Make sure that all commits have a [`Changelog`](https://github.com/mendersoftware/mender/blob/master/CONTRIBUTING.md#changelog-tags) tag. If nothing should be added to the Changelog, add a `Changelog: None` tag. If there is a change, add `Changelog: Commit`, or `Changelog: Title`, depending on what should be included in the changelog.

- [x] Make sure that all commits are signed with [`git --signoff`](https://git-scm.com/book/en/v2/Git-Tools-Signing-Your-Work). Also note that the signoff author must match the author of the commit.

### Description

Please describe your pull request.

Thank you!
