### PR TITLE
MEN-4462: Add a config for demo configuration during conversion

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -51,7 +51,9 @@ RUN apt-get update && env DEBIAN_FRONTEND=noninteractive apt-get install -y \
     zip  \
     unzip \
 # manipulate binary and hex
-    xxd
+    xxd \
+# JSON power tool
+    jq
 
 COPY --from=build /root/pxz/pxz /usr/bin/pxz
 

--- a/configs/mender_convert_demo_config
+++ b/configs/mender_convert_demo_config
@@ -1,0 +1,35 @@
+# Install all the add-on's by default
+MENDER_ADDON_CONNECT_INSTALL="y"
+MENDER_ADDON_CONFIGURE_INSTALL="y"
+
+enable_demo_configuration_in_file() {
+
+    log_info "Modifying mender.conf to follow a demo setup"
+
+    run_and_log_cmd "mkdir -p work/rootfs/etc/mender"
+
+    if [ ! -f work/rootfs/etc/mender/mender.conf ]; then
+        log_error "No Mender configuration file found in the work folder."
+        exit 1
+    fi
+
+    if [ ! -f work/rootfs/etc/mender/mender-connect.conf ]; then
+        log_info "Installing the mender-connect.conf file"
+        cat <<- EOF > work/rootfs/etc/mender/mender-connect.conf
+            {
+                "ShellCommand": "/bin/sh",
+                "User": "root"
+            }
+EOF
+        run_and_log_cmd "sudo chmod 0600 work/rootfs/etc/mender/mender-connect.conf"
+    fi
+
+    log_info "Adding the demo configuration to the Mender client"
+    tmpfile=work/mender.conf.bak
+    run_and_log_cmd "cat work/rootfs/etc/mender/mender.conf |  jq '.InventoryPollIntervalSeconds=5 | .RetryPollIntervalSeconds=30 |    .UpdatePollIntervalSeconds=5' > ${tmpfile}"
+    run_and_log_cmd "cp ${tmpfile} work/rootfs/etc/mender/mender.conf"
+    run_and_log_cmd "sudo chmod 0600 work/rootfs/etc/mender/mender.conf"
+    log_warn "New mender.conf contents: $(cat  work/rootfs/etc/mender/mender.conf)"
+
+}
+PLATFORM_MODIFY_HOOKS+=(enable_demo_configuration_in_file)

--- a/mender-convert-modify
+++ b/mender-convert-modify
@@ -105,7 +105,7 @@ deb_arch=$(probe_debian_arch_name)
 
 if [ "${MENDER_CLIENT_INSTALL}" = "y" ]; then
 
-    log_info "Installing Mender Client version ${MENDER_CLIENT_VERSION}"
+    log_info "Installing Mender client version ${MENDER_CLIENT_VERSION}"
 
     if [ "${MENDER_CLIENT_VERSION}" = "latest" ]; then
         deb_name=$(deb_from_repo_dist_get "work/deb-packages" ${MENDER_APT_REPO_URL} ${deb_arch} "stable" "mender-client")

--- a/mender-convert-modify
+++ b/mender-convert-modify
@@ -290,6 +290,15 @@ EOF
 run_and_log_cmd "sudo cp work/mender.conf.data work/rootfs/data/mender/mender.conf"
 run_and_log_cmd "sudo chmod 600 work/rootfs/data/mender/mender.conf"
 
+if [ -f resources/mender.conf ]; then
+    log_info "Installing the local mender.conf file"
+    run_and_log_cmd "mkdir -p work/rootfs/etc/mender"
+    run_and_log_cmd "cp resources/mender.conf work/rootfs/etc/mender"
+    run_and_log_cmd "sudo chmod 600 work/rootfs/etc/mender/mender.conf"
+else
+    log_warn "No mender.conf file found in resources. Have you remembered to run the bootstrap script?"
+fi
+
 if [ -z "${MENDER_DEVICE_TYPE}" ]; then
     # Observed systems who do not have this file, e.g images generated with mkosi
     if [ -f work/rootfs/etc/hostname ]; then

--- a/scripts/bootstrap-rootfs-overlay-demo-server.sh
+++ b/scripts/bootstrap-rootfs-overlay-demo-server.sh
@@ -56,27 +56,15 @@ if [ -e ${output_dir} ]; then
      sudo chown -R $(id -u) ${output_dir}
      sudo chgrp -R $(id -g) ${output_dir}
 fi
+
 mkdir -p ${output_dir}/etc/mender
-cat <<- EOF > ${output_dir}/etc/mender/mender.conf
+mkdir -p ${root_dir}/resources
+cat <<- EOF > ${root_dir}/resources/mender.conf
 {
-  "InventoryPollIntervalSeconds": 5,
-  "RetryPollIntervalSeconds": 30,
   "ServerURL": "https://docker.mender.io",
-  "ServerCertificate": "/etc/mender/server.crt",
-  "UpdatePollIntervalSeconds": 5
+  "ServerCertificate": "/etc/mender/server.crt"
 }
 EOF
-
-chmod 600 ${output_dir}/etc/mender/mender.conf
-
-cat <<- EOF > ${output_dir}/etc/mender/mender-connect.conf
-{
-  "ShellCommand": "/bin/sh",
-  "User": "root"
-}
-EOF
-
-chmod 600 ${output_dir}/etc/mender/mender-connect.conf
 
 cat <<- EOF > ${output_dir}/etc/hosts
 127.0.0.1	localhost
@@ -93,4 +81,4 @@ wget -q "https://raw.githubusercontent.com/mendersoftware/mender/master/support/
 sudo chown -R 0 ${output_dir}
 sudo chgrp -R 0 ${output_dir}
 
-echo "Configuration file for using Demo Mender Server written to: ${output_dir}/etc/mender"
+echo "Configuration file for using Demo Mender Server written to: ${root_dir}/resources/mender.conf"

--- a/scripts/bootstrap-rootfs-overlay-hosted-server.sh
+++ b/scripts/bootstrap-rootfs-overlay-hosted-server.sh
@@ -57,20 +57,15 @@ if [ -e ${output_dir} ]; then
      sudo chown -R $(id -u) ${output_dir}
      sudo chgrp -R $(id -g) ${output_dir}
 fi
-mkdir -p ${output_dir}/etc/mender
-cat <<- EOF > ${output_dir}/etc/mender/mender.conf
+mkdir -p ${root_dir}/resources
+cat <<- EOF > ${root_dir}/resources/mender.conf
 {
-  "InventoryPollIntervalSeconds": 5,
-  "RetryPollIntervalSeconds": 30,
   "ServerURL": "https://hosted.mender.io/",
-  "TenantToken": "${tenant_token}",
-  "UpdatePollIntervalSeconds": 5
+  "TenantToken": "${tenant_token}"
 }
 EOF
-
-chmod 600 ${output_dir}/etc/mender/mender.conf
 
 sudo chown -R 0 ${output_dir}
 sudo chgrp -R 0 ${output_dir}
 
-echo "Configuration file for using Hosted Mender written to: ${output_dir}/etc/mender"
+echo "Configuration file for using Hosted Mender written to: ${root_dir}/resources/mender.conf"

--- a/scripts/bootstrap-rootfs-overlay-production-server.sh
+++ b/scripts/bootstrap-rootfs-overlay-production-server.sh
@@ -61,29 +61,21 @@ if [ -e ${output_dir} ]; then
     sudo chown -R $(id -u) ${output_dir}
     sudo chgrp -R $(id -g) ${output_dir}
 fi
-mkdir -p ${output_dir}/etc/mender
-cat <<- EOF > ${output_dir}/etc/mender/mender.conf
+
+mkdir -p ${root_dir}/resources
+cat <<- EOF > ${root_dir}/resources/mender.conf
 {
-  "InventoryPollIntervalSeconds": 5,
-  "RetryPollIntervalSeconds": 30,
   "ServerURL": "${server_url}",
 EOF
 
 if [ -n "${server_cert}" ]; then
-    cat <<- EOF >> ${output_dir}/etc/mender/mender.conf
-  "ServerCertificate": "/etc/mender/server.crt",
+    cat <<- EOF >> ${root_dir}/resources/mender.conf
+  "ServerCertificate": "/etc/mender/server.crt"
 EOF
     cp -f "${server_cert}" ${output_dir}/etc/mender/server.crt
 fi
 
-cat <<- EOF >> ${output_dir}/etc/mender/mender.conf
-  "UpdatePollIntervalSeconds": 5
-}
-EOF
-
-chmod 600 ${output_dir}/etc/mender/mender.conf
-
 sudo chown -R 0 ${output_dir}
 sudo chgrp -R 0 ${output_dir}
 
-echo "Configuration file for using Production Mender Server written to: ${output_dir}/etc/mender"
+echo "Configuration file for using Production Mender Server written to: ${root_dir}/resources/mender.conf"


### PR DESCRIPTION
This moves the device configuration to a config script in configs/, from the
previous setup in the bootstrap scripts.

It does so by creating a new resources/ folder in the top-level directory, which
is then populated with the configuration file, and the server parameters only.

When the conversion is run with the demo configuration
configs/mender_convert_demo_config the conversion will install all the add-on's
available, and modify the configuration file in resources to align with our
regular Mender demo configuration.