### PR TITLE
Add checksumming to artifacts from temporary S3 bucket.

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -107,10 +107,18 @@ test:check-shell-formatting:
       -c configs/images/raspberrypi_raspbian_config
       -c versions_override_config
 
-    # Upload to temporary S3 bucket
+    # Collect artifacts.
     - mv deploy ${RASPBERRYPI_PLATFORM}
     - tar czf ${RASPBERRYPI_PLATFORM}.tar.gz ${RASPBERRYPI_PLATFORM}
+    # Compute checksum
+    - mkdir checksums
+    - sha256sum ${RASPBERRYPI_PLATFORM}.tar.gz > checksums/${RASPBERRYPI_PLATFORM}.tar.gz.sha256
+    # Upload to temporary S3 bucket
     - aws s3 cp ${RASPBERRYPI_PLATFORM}.tar.gz s3://mender-gitlab-tmp-storage/$CI_PROJECT_NAME/$CI_PIPELINE_ID/${RASPBERRYPI_PLATFORM}.tar.gz
+
+  artifacts:
+    paths:
+      - checksums
 
 convert_raspbian_raspberrypi3:
   <<: *convert_raspbian
@@ -181,6 +189,8 @@ convert_raspbian_raspberrypi4:
   script:
     # Fetch artifacts from temporary S3 bucket
     - aws s3 cp s3://mender-gitlab-tmp-storage/$CI_PROJECT_NAME/$CI_PIPELINE_ID/${RASPBERRYPI_PLATFORM}.tar.gz ${RASPBERRYPI_PLATFORM}.tar.gz
+    # Check checksum
+    - sha256sum -c checksums/${RASPBERRYPI_PLATFORM}.tar.gz.sha256
     - tar xzf ${RASPBERRYPI_PLATFORM}.tar.gz
     - mv ${RASPBERRYPI_PLATFORM} deploy
     # Extract converted Raspbian artifacts
@@ -239,6 +249,8 @@ publish:s3:
     # Fetch artifacts from temporary S3 bucket
     - for RASPBERRYPI_PLATFORM in raspberrypi3 raspberrypi4; do
     -   aws s3 cp s3://mender-gitlab-tmp-storage/$CI_PROJECT_NAME/$CI_PIPELINE_ID/${RASPBERRYPI_PLATFORM}.tar.gz ${RASPBERRYPI_PLATFORM}.tar.gz
+    #   Check checksum
+    -   sha256sum -c checksums/${RASPBERRYPI_PLATFORM}.tar.gz.sha256
     -   tar xzf ${RASPBERRYPI_PLATFORM}.tar.gz
     - done
   script:


### PR DESCRIPTION
The temporary S3 bucket is not perfectly secure, because credentials
can be obtained by outsiders by submitting a malicious pull request,
and then later they can be used to manipulate objects while a
privileged pipeline is running (during a release). Fix this by
submitting a checksum file using the standard Gitlab artifact
mechanism, and check that what we uploaded in one job, is what we get
in the next one.

Changelog: None

Signed-off-by: Kristian Amlie <kristian.amlie@northern.tech>
(cherry picked from commit 9d18a8717d8812dba135c3e2231e786afeb1ac6c)
