### PR TITLE
MEN-5057: configs/images/raspberrypi_raspbian_config: Allow APT Suite change

### DIFF
--- a/configs/images/raspberrypi_raspbian_config
+++ b/configs/images/raspberrypi_raspbian_config
@@ -49,3 +49,18 @@ EOF
 }
 
 PLATFORM_MODIFY_HOOKS+=(grow_data_partition)
+
+#
+# Allow APT Suite change in the release info
+#
+# Upstream repository http://raspbian.raspberrypi.org/raspbian has changed buster
+# release suite from "stable" to "oldstable". The following configuration option
+# allows APT to update without user interaction.
+# This is the default un newer versions of apt, see:
+#   https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=931566
+#
+function apt_allow_release_change_suite() {
+    run_and_log_cmd "echo 'Acquire::AllowReleaseInfoChange::Suite \"true\";' \
+                     | sudo tee work/rootfs/etc/apt/apt.conf.d/99release-change-suite"
+}
+PLATFORM_MODIFY_HOOKS+=(apt_allow_release_change_suite)


### PR DESCRIPTION
As per today, our pre-converted image ships with Debian buster, while
Raspberry Pi OS APT repository has moved already to Debian bullseye,
moving buster from "stable" to "oldstable".

This configuration allows apt to update the information without
interaction from the user. This is the default behaviour in newer
versions of apt, see https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=931566