### PR TITLE
MEN-5410: Modify Debian packages installation for new repositories

### DIFF
--- a/configs/mender_convert_config
+++ b/configs/mender_convert_config
@@ -146,9 +146,13 @@ MENDER_ADDON_CONFIGURE_VERSION="latest"
 # what you are doing.
 MENDER_STORAGE_URL="https://downloads.mender.io"
 
-# Mender APT repo, containing binary files, do not modify this unless you know
+# Mender APT repo url, containing binary files, do not modify this unless you know
 # what you are doing.
 MENDER_APT_REPO_URL="${MENDER_STORAGE_URL}/repos/debian"
+
+# Mender APT repo available distributions, do not modify this unless you know
+# what you are doing.
+MENDER_APT_REPO_DISTS="debian/buster debian/bullseye ubuntu/bionic ubuntu/focal"
 
 # Mender GitHub organization URL prefix
 MENDER_GITHUB_ORG="https://github.com/mendersoftware"

--- a/mender-convert-modify
+++ b/mender-convert-modify
@@ -102,17 +102,23 @@ mkdir -p work/deb-packages
 log_info "Installing Mender client and related files"
 
 deb_arch=$(probe_debian_arch_name)
+deb_distro=$(probe_debian_distro_name)
+deb_codename=$(probe_debian_distro_codename)
+if ! [[ "$MENDER_APT_REPO_DISTS" == *"${deb_distro}/${deb_codename}"* ]]; then
+    deb_distro="debian"
+    deb_codename="buster"
+fi
 
 if [ "${MENDER_CLIENT_INSTALL}" = "y" ]; then
 
     log_info "Installing Mender client version ${MENDER_CLIENT_VERSION}"
 
     if [ "${MENDER_CLIENT_VERSION}" = "latest" ]; then
-        deb_name=$(deb_from_repo_dist_get "work/deb-packages" ${MENDER_APT_REPO_URL} ${deb_arch} "stable" "mender-client")
+        deb_name=$(deb_from_repo_dist_get "work/deb-packages" ${MENDER_APT_REPO_URL} ${deb_arch} "${deb_distro}/${deb_codename}/stable" "mender-client")
     elif [ "${MENDER_CLIENT_VERSION}" = "master" ]; then
-        deb_name=$(deb_from_repo_dist_get "work/deb-packages" ${MENDER_APT_REPO_URL} ${deb_arch} "experimental" "mender-client")
+        deb_name=$(deb_from_repo_dist_get "work/deb-packages" ${MENDER_APT_REPO_URL} ${deb_arch} "${deb_distro}/${deb_codename}/experimental" "mender-client")
     else
-        DEBIAN_REVISION="-1"
+        DEBIAN_REVISION="-1+${deb_distro}+${deb_codename}"
         deb_name=$(deb_from_repo_pool_get "work/deb-packages" ${MENDER_APT_REPO_URL} ${deb_arch} "mender-client" "${MENDER_CLIENT_VERSION}${DEBIAN_REVISION}")
     fi
 
@@ -133,11 +139,11 @@ if [ "${MENDER_ADDON_CONNECT_INSTALL}" = "y" ]; then
     log_info "Installing Mender Connect addon"
 
     if [ "${MENDER_ADDON_CONNECT_VERSION}" = "latest" ]; then
-        deb_name=$(deb_from_repo_dist_get "work/deb-packages" ${MENDER_APT_REPO_URL} ${deb_arch} "stable" "mender-connect")
+        deb_name=$(deb_from_repo_dist_get "work/deb-packages" ${MENDER_APT_REPO_URL} ${deb_arch} "${deb_distro}/${deb_codename}/stable" "mender-connect")
     elif [ "${MENDER_ADDON_CONNECT_VERSION}" = "master" ]; then
-        deb_name=$(deb_from_repo_dist_get "work/deb-packages" ${MENDER_APT_REPO_URL} ${deb_arch} "experimental" "mender-connect")
+        deb_name=$(deb_from_repo_dist_get "work/deb-packages" ${MENDER_APT_REPO_URL} ${deb_arch} "${deb_distro}/${deb_codename}/experimental" "mender-connect")
     else
-        DEBIAN_REVISION="-1"
+        DEBIAN_REVISION="-1+${deb_distro}+${deb_codename}"
         deb_name=$(deb_from_repo_pool_get "work/deb-packages" ${MENDER_APT_REPO_URL} ${deb_arch} "mender-connect" "${MENDER_ADDON_CONNECT_VERSION}${DEBIAN_REVISION}")
     fi
 
@@ -152,11 +158,11 @@ if [ "${MENDER_ADDON_CONFIGURE_INSTALL}" = "y" ]; then
     log_info "Installing Mender Configure addon"
 
     if [ "${MENDER_ADDON_CONFIGURE_VERSION}" = "latest" ]; then
-        deb_name=$(deb_from_repo_dist_get "work/deb-packages" ${MENDER_APT_REPO_URL} ${deb_arch} "stable" "mender-configure")
+        deb_name=$(deb_from_repo_dist_get "work/deb-packages" ${MENDER_APT_REPO_URL} ${deb_arch} "${deb_distro}/${deb_codename}/stable" "mender-configure")
     elif [ "${MENDER_ADDON_CONFIGURE_VERSION}" = "master" ]; then
-        deb_name=$(deb_from_repo_dist_get "work/deb-packages" ${MENDER_APT_REPO_URL} ${deb_arch} "experimental" "mender-configure")
+        deb_name=$(deb_from_repo_dist_get "work/deb-packages" ${MENDER_APT_REPO_URL} ${deb_arch} "${deb_distro}/${deb_codename}/experimental" "mender-configure")
     else
-        DEBIAN_REVISION="-1"
+        DEBIAN_REVISION="-1+${deb_distro}+${deb_codename}"
         deb_name=$(deb_from_repo_pool_get "work/deb-packages" ${MENDER_APT_REPO_URL} ${deb_arch} "mender-configure" "${MENDER_ADDON_CONFIGURE_VERSION}${DEBIAN_REVISION}")
     fi
 

--- a/mender-convert-modify
+++ b/mender-convert-modify
@@ -122,7 +122,7 @@ fi
 
 if [ "${MENDER_ADDON_CONFIGURE_INSTALL}" = "y" ]; then
     log_info "Installing Mender Configure addon"
-    deb_get_and_install_pacakge mender-configure "${MENDER_ADDON_CONFIGURE_VERSION}"
+    deb_get_and_install_pacakge mender-configure "${MENDER_ADDON_CONFIGURE_VERSION}" "true"
 fi
 
 # Do this unconditionally even if not installing add-ons. The reason is that if

--- a/mender-convert-modify
+++ b/mender-convert-modify
@@ -97,36 +97,14 @@ mkdir -p work/rootfs
 sudo mount ${boot_part} work/boot
 sudo mount ${root_part} work/rootfs
 
-mkdir -p work/deb-packages
-
 log_info "Installing Mender client and related files"
 
-deb_arch=$(probe_debian_arch_name)
-deb_distro=$(probe_debian_distro_name)
-deb_codename=$(probe_debian_distro_codename)
-if ! [[ "$MENDER_APT_REPO_DISTS" == *"${deb_distro}/${deb_codename}"* ]]; then
-    deb_distro="debian"
-    deb_codename="buster"
-fi
-
 if [ "${MENDER_CLIENT_INSTALL}" = "y" ]; then
-
     log_info "Installing Mender client version ${MENDER_CLIENT_VERSION}"
-
-    if [ "${MENDER_CLIENT_VERSION}" = "latest" ]; then
-        deb_name=$(deb_from_repo_dist_get "work/deb-packages" ${MENDER_APT_REPO_URL} ${deb_arch} "${deb_distro}/${deb_codename}/stable" "mender-client")
-    elif [ "${MENDER_CLIENT_VERSION}" = "master" ]; then
-        deb_name=$(deb_from_repo_dist_get "work/deb-packages" ${MENDER_APT_REPO_URL} ${deb_arch} "${deb_distro}/${deb_codename}/experimental" "mender-client")
-    else
-        DEBIAN_REVISION="-1+${deb_distro}+${deb_codename}"
-        deb_name=$(deb_from_repo_pool_get "work/deb-packages" ${MENDER_APT_REPO_URL} ${deb_arch} "mender-client" "${MENDER_CLIENT_VERSION}${DEBIAN_REVISION}")
-    fi
-
-    deb_extract_package "work/deb-packages/${deb_name}" "work/rootfs/"
+    deb_get_and_install_pacakge mender-client "${MENDER_CLIENT_VERSION}"
 
     # Save installed client version for tests in Yocto variable format
-    testscfg_add "PREFERRED_VERSION_mender-client" "$(echo ${deb_name} | sed -r 's/.*_([0-9]+\.[0-9]+\.[0-9]+).*/\1/')"
-
+    testscfg_add "PREFERRED_VERSION_mender-client" "$(echo ${DEB_NAME} | sed -r 's/.*_([0-9]+\.[0-9]+\.[0-9]+).*/\1/')"
 fi
 
 if [ "${MENDER_ENABLE_SYSTEMD}" == "y" ]; then
@@ -135,38 +113,16 @@ if [ "${MENDER_ENABLE_SYSTEMD}" == "y" ]; then
 fi
 
 if [ "${MENDER_ADDON_CONNECT_INSTALL}" = "y" ]; then
-
     log_info "Installing Mender Connect addon"
-
-    if [ "${MENDER_ADDON_CONNECT_VERSION}" = "latest" ]; then
-        deb_name=$(deb_from_repo_dist_get "work/deb-packages" ${MENDER_APT_REPO_URL} ${deb_arch} "${deb_distro}/${deb_codename}/stable" "mender-connect")
-    elif [ "${MENDER_ADDON_CONNECT_VERSION}" = "master" ]; then
-        deb_name=$(deb_from_repo_dist_get "work/deb-packages" ${MENDER_APT_REPO_URL} ${deb_arch} "${deb_distro}/${deb_codename}/experimental" "mender-connect")
-    else
-        DEBIAN_REVISION="-1+${deb_distro}+${deb_codename}"
-        deb_name=$(deb_from_repo_pool_get "work/deb-packages" ${MENDER_APT_REPO_URL} ${deb_arch} "mender-connect" "${MENDER_ADDON_CONNECT_VERSION}${DEBIAN_REVISION}")
-    fi
-
-    deb_extract_package "work/deb-packages/${deb_name}" "work/rootfs/"
+    deb_get_and_install_pacakge mender-connect "${MENDER_ADDON_CONNECT_VERSION}"
 
     run_and_log_cmd "sudo ln -sf /lib/systemd/system/mender-connect.service \
         work/rootfs/etc/systemd/system/multi-user.target.wants/mender-connect.service"
 fi
 
 if [ "${MENDER_ADDON_CONFIGURE_INSTALL}" = "y" ]; then
-
     log_info "Installing Mender Configure addon"
-
-    if [ "${MENDER_ADDON_CONFIGURE_VERSION}" = "latest" ]; then
-        deb_name=$(deb_from_repo_dist_get "work/deb-packages" ${MENDER_APT_REPO_URL} ${deb_arch} "${deb_distro}/${deb_codename}/stable" "mender-configure")
-    elif [ "${MENDER_ADDON_CONFIGURE_VERSION}" = "master" ]; then
-        deb_name=$(deb_from_repo_dist_get "work/deb-packages" ${MENDER_APT_REPO_URL} ${deb_arch} "${deb_distro}/${deb_codename}/experimental" "mender-configure")
-    else
-        DEBIAN_REVISION="-1+${deb_distro}+${deb_codename}"
-        deb_name=$(deb_from_repo_pool_get "work/deb-packages" ${MENDER_APT_REPO_URL} ${deb_arch} "mender-configure" "${MENDER_ADDON_CONFIGURE_VERSION}${DEBIAN_REVISION}")
-    fi
-
-    deb_extract_package "work/deb-packages/${deb_name}" "work/rootfs/"
+    deb_get_and_install_pacakge mender-configure "${MENDER_ADDON_CONFIGURE_VERSION}"
 fi
 
 # Do this unconditionally even if not installing add-ons. The reason is that if

--- a/modules/deb.sh
+++ b/modules/deb.sh
@@ -82,7 +82,8 @@ function deb_from_repo_pool_get()  {
     local -r deb_package_path="pool/${component}/${initial}/${package}/${package}_${version}_${architecture}.deb"
 
     local -r filename=$(basename $deb_package_path)
-    run_and_log_cmd_noexit "wget -Nq ${repo_url}/${deb_package_path} -P ${download_dir}"
+    local -r deb_package_url=$(echo ${repo_url}/${deb_package_path} | sed 's/+/%2B/g')
+    run_and_log_cmd_noexit "wget -Nq ${deb_package_url} -P ${download_dir}"
     local exit_code=$?
 
     rm -f /tmp/Packages

--- a/modules/probe.sh
+++ b/modules/probe.sh
@@ -97,6 +97,29 @@ probe_debian_arch_name() {
     echo "${deb_arch}"
 }
 
+# Prints Debian distro name based on ID from /etc/os-release
+#
+# Special handling for raspbian, where ID_LIKE is used instead
+#
+# No input parameters and these work on the assumption that boot and root parts
+# are mounted at work/boot and work/rootfs
+probe_debian_distro_name() {
+    distro_name="$(. work/rootfs/etc/os-release && echo "$ID")"
+    if [[ "$distro_name" == "raspbian" ]]; then
+        distro_name="$(. work/rootfs/etc/os-release && echo "$ID_LIKE")"
+    fi
+    echo "${distro_name}"
+}
+
+# Prints Debian distro codename based on VERSION_CODENAME from /etc/os-release
+#
+# No input parameters and these work on the assumption that boot and root parts
+# are mounted at work/boot and work/rootfs
+probe_debian_distro_codename() {
+    distro_codename="$(. work/rootfs/etc/os-release && echo "$VERSION_CODENAME")"
+    echo "${distro_codename}"
+}
+
 # Prints GRUB EFI target name depending on target architecture
 #
 # This is what the file name should be when put on target boot part.

--- a/modules/run.sh
+++ b/modules/run.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Copyright 2019 Northern.tech AS
+# Copyright 2022 Northern.tech AS
 #
 #  Licensed under the Apache License, Version 2.0 (the "License");
 #  you may not use this file except in compliance with the License.
@@ -14,7 +14,7 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-# Run a command, capture output and log it
+# Run a command, capture and log output, and exit on non-zero return code
 #
 #  $1 - command to run
 function run_and_log_cmd() {
@@ -30,4 +30,20 @@ function run_and_log_cmd() {
     if [[ ${exit_code} -ne 0 ]]; then
         exit ${exit_code}
     fi
+}
+
+# Run a command, capture and log output, and return the command's return code
+#
+#  $1 - command to run
+function run_and_log_cmd_noexit() {
+    local -r cmd="${1}"
+    local -r position="(${BASH_SOURCE[1]}:${BASH_LINENO[0]}): ${FUNCNAME[0]:+${FUNCNAME[0]}(): }"
+    local exit_code=0
+    output="$({ eval ${cmd}; } 2>&1)" || exit_code=$?
+    local log_msg="Running: ${position} \n\r\n\r\t${cmd}"
+    if [[ "${output}" != "" ]]; then
+        log_msg="${log_msg}\n\t${output}\n"
+    fi
+    log_debug "${log_msg}"
+    return ${exit_code}
 }


### PR DESCRIPTION
    Changelog: Download and install Debian packages taking into account the
    target OS. Now downloads.mender.io serves four distributions: the two
    latests releases for Debian and Ubuntu. Probe /etc/os-release to figure
    out the correct package to install, and fallback to Debian Buster
    packages which was the previous default.
