### PR TITLE
docker-mender-convert: fix mktemp invocation for macOS

### DIFF
--- a/docker-mender-convert
+++ b/docker-mender-convert
@@ -26,7 +26,7 @@ MENDER_CONVERT_DIR="$(pwd)"
 MENDER_CONVERT_VERSION=$(git_mender_convert_version)
 
 # Create a unique work directory so we can run multiple containers in parallel
-WORK_DIR=$(mktemp -d -p $(pwd) -t work.XXXX)
+WORK_DIR=$(mktemp -d 2>/dev/null || mktemp -d -t 'mytmpdir')
 WORK_SUFFIX=$(echo $WORK_DIR | awk -F. '{print $NF}')
 LOG_FILE="convert.log.${WORK_SUFFIX}"
 


### PR DESCRIPTION
docker-mender-convert: fix mktemp invocation for macOS

As suggested per https://hub.mender.io/t/bug-convert-a-raw-disk-image-in-macos-fails-mktemp-illegal-option-p/4428/3,
the '-p' switch is not supported on macOS and needs to be worked around.

Signed-off-by: Josef Holzmayr <josef.holzmayr@northern.tech>