### PR TITLE
fix: Detect when EFI is not available and disable grub.d integration.

### DIFF
--- a/mender-convert-modify
+++ b/mender-convert-modify
@@ -140,7 +140,9 @@ if [ "${MENDER_GRUB_EFI_INTEGRATION}" == "y" ]; then
     # Check for known U-Boot problems in all files on the boot partition.
     check_for_broken_uboot_uefi_support work/boot
 
-    if [ "$MENDER_GRUB_D_INTEGRATION" = y ] || ( [ "$MENDER_GRUB_D_INTEGRATION" = auto ] && supports_grub_d "work/rootfs" ); then
+    if [ "$MENDER_GRUB_D_INTEGRATION" = y ] || ( [ "$MENDER_GRUB_D_INTEGRATION" = auto ] \
+        && supports_grub_d_and_efi "work/boot" "work/rootfs" ); then
+
         # No need to install Grub, use the one already present, and only install
         # our tools.
         log_info "Not installing GRUB EFI bootloader, relying on platform provided one."

--- a/modules/probe.sh
+++ b/modules/probe.sh
@@ -344,8 +344,10 @@ is_efi_compatible_kernel() {
     return 0
 }
 
-supports_grub_d() {
-    test -d "$1"/etc/grub.d || return 1
+supports_grub_d_and_efi() {
+    test -d "$1"/EFI || return 1
+    test -d "$2"/boot/efi || return 1
+    test -d "$2"/etc/grub.d || return 1
 
     # Because we are executing programs inside a chroot in the image, we cannot
     # currently convert non-native architectures to use grub.d integration. See


### PR DESCRIPTION
Note that we will still use EFI, since Mender doesn't support anything
else, but we will avoid grub.d integration since it won't be prepared
for it in this configuration. Instead the legacy method with a custom
Mender boot script will be used.

Inspired by this thread on Mender Hub:
https://hub.mender.io/t/problems-converting-a-packer-debian11-img-with-mender-convert/5054

Changelog: Title
Ticket: None

Signed-off-by: Kristian Amlie <kristian.amlie@northern.tech>
