### PR TITLE
fix: user defined overlay not to be ignored with demo config enabled

### DIFF
--- a/configs/mender_convert_demo_config
+++ b/configs/mender_convert_demo_config
@@ -32,4 +32,4 @@ EOF
     log_warn "New mender.conf contents: $(cat  work/rootfs/etc/mender/mender.conf)"
 
 }
-PLATFORM_MODIFY_HOOKS+=(enable_demo_configuration_in_file)
+OVERLAY_MODIFY_HOOKS+=(enable_demo_configuration_in_file)

--- a/configs/mender_convert_demo_config
+++ b/configs/mender_convert_demo_config
@@ -9,7 +9,7 @@ enable_demo_configuration_in_file() {
     run_and_log_cmd "mkdir -p work/rootfs/etc/mender"
 
     if [ ! -f work/rootfs/etc/mender/mender.conf ]; then
-        log_error "No Mender configuration file found in the work folder."
+        log_error 'No Mender configuration file found in the work folder. Either run a bootstrap script and pass the output directory as an overlay to mender-convert, or pass your own overlay with an $OVERLAY/etc/mender/mender.conf file.'
         exit 1
     fi
 

--- a/mender-convert-modify
+++ b/mender-convert-modify
@@ -190,15 +190,6 @@ EOF
 run_and_log_cmd "sudo cp work/mender.conf.data work/rootfs/data/mender/mender.conf"
 run_and_log_cmd "sudo chmod 600 work/rootfs/data/mender/mender.conf"
 
-if [ -f input/resources/mender.conf ]; then
-    log_info "Installing the local mender.conf file"
-    run_and_log_cmd "mkdir -p work/rootfs/etc/mender"
-    run_and_log_cmd "cp input/resources/mender.conf work/rootfs/etc/mender"
-    run_and_log_cmd "sudo chmod 600 work/rootfs/etc/mender/mender.conf"
-else
-    log_warn "No mender.conf file found in input/resources. Have you remembered to run the bootstrap script?"
-fi
-
 if [ -z "${MENDER_DEVICE_TYPE}" ]; then
     # Observed systems who do not have this file, e.g images generated with mkosi
     if [ -f work/rootfs/etc/hostname ]; then

--- a/scripts/bootstrap-rootfs-overlay-demo-server.sh
+++ b/scripts/bootstrap-rootfs-overlay-demo-server.sh
@@ -16,12 +16,6 @@
 # Exit if any command exits with a non-zero exit status.
 set -o errexit
 
-root_dir=$( cd "$( dirname "${BASH_SOURCE[0]}")/../"  && pwd)
-if [ "${root_dir}" != "${PWD}" ]; then
-    echo "You must execute $(basename $0) from the root directory: ${root_dir}"
-    exit 1
-fi
-
 server_ip=""
 output_dir=""
 while (("$#")); do
@@ -57,8 +51,7 @@ if [ -e ${output_dir} ]; then
 fi
 
 mkdir -p ${output_dir}/etc/mender
-mkdir -p ${root_dir}/input/resources
-cat <<- EOF > ${root_dir}/input/resources/mender.conf
+cat <<- EOF > ${output_dir}/etc/mender/mender.conf
 {
   "ServerURL": "https://docker.mender.io",
   "ServerCertificate": "/etc/mender/server.crt"
@@ -80,4 +73,4 @@ wget -q "https://raw.githubusercontent.com/mendersoftware/mender/master/support/
 sudo chown -R 0 ${output_dir}
 sudo chgrp -R 0 ${output_dir}
 
-echo "Configuration file for using Demo Mender Server written to: ${root_dir}/input/resources/mender.conf"
+echo "Configuration file for using Demo Mender Server written to: ${output_dir}/etc/mender/mender.conf"

--- a/scripts/bootstrap-rootfs-overlay-hosted-server.sh
+++ b/scripts/bootstrap-rootfs-overlay-hosted-server.sh
@@ -16,12 +16,6 @@
 # Exit if any command exits with a non-zero exit status.
 set -o errexit
 
-root_dir=$( cd "$( dirname "${BASH_SOURCE[0]}")/../"  && pwd)
-if [ "${root_dir}" != "${PWD}" ]; then
-    echo "You must execute $(basename $0) from the root directory: ${root_dir}"
-    exit 1
-fi
-
 tenant_token=""
 output_dir=""
 while (("$#")); do
@@ -56,8 +50,8 @@ if [ -e ${output_dir} ]; then
      sudo chown -R $(id -u) ${output_dir}
      sudo chgrp -R $(id -g) ${output_dir}
 fi
-mkdir -p ${root_dir}/input/resources
-cat <<- EOF > ${root_dir}/input/resources/mender.conf
+mkdir -p ${output_dir}/etc/mender
+cat <<- EOF > ${output_dir}/etc/mender/mender.conf
 {
   "ServerURL": "https://hosted.mender.io/",
   "TenantToken": "${tenant_token}"
@@ -67,4 +61,4 @@ EOF
 sudo chown -R 0 ${output_dir}
 sudo chgrp -R 0 ${output_dir}
 
-echo "Configuration file for using Hosted Mender written to: ${root_dir}/input/resources/mender.conf"
+echo "Configuration file for using Hosted Mender written to: ${output_dir}/etc/mender/mender.conf"

--- a/scripts/bootstrap-rootfs-overlay-production-server.sh
+++ b/scripts/bootstrap-rootfs-overlay-production-server.sh
@@ -16,12 +16,6 @@
 # Exit if any command exits with a non-zero exit status.
 set -o errexit
 
-root_dir=$( cd "$( dirname "${BASH_SOURCE[0]}")/../"  && pwd)
-if [ "${root_dir}" != "${PWD}" ]; then
-    echo "You must execute $(basename $0) from the root directory: ${root_dir}"
-    exit 1
-fi
-
 server_url=""
 output_dir=""
 while (("$#")); do
@@ -61,24 +55,24 @@ if [ -e ${output_dir} ]; then
     sudo chgrp -R $(id -g) ${output_dir}
 fi
 
-mkdir -p ${root_dir}/input/resources
-cat <<- EOF > ${root_dir}/input/resources/mender.conf
+mkdir -p ${output_dir}/etc/mender
+cat <<- EOF > ${output_dir}/etc/mender/mender.conf
 {
   "ServerURL": "${server_url}",
 EOF
 
 if [ -n "${server_cert}" ]; then
-    cat <<- EOF >> ${root_dir}/input/resources/mender.conf
+    cat <<- EOF >> ${output_dir}/etc/mender/mender.conf
   "ServerCertificate": "/etc/mender/server.crt"
 EOF
     cp -f "${server_cert}" ${output_dir}/etc/mender/server.crt
 fi
 
-cat <<- EOF >> ${root_dir}/input/resources/mender.conf
+cat <<- EOF >> ${output_dir}/etc/mender/mender.conf
 }
 EOF
 
 sudo chown -R 0 ${output_dir}
 sudo chgrp -R 0 ${output_dir}
 
-echo "Configuration file for using Production Mender Server written to: ${root_dir}/input/resources/mender.conf"
+echo "Configuration file for using Production Mender Server written to: ${output_dir}/etc/mender/mender.conf"


### PR DESCRIPTION
Log:
````
2022-09-28 08:52:37 [INFO] [mender-convert-modify] Attempting to merge /etc/mender/mender.conf in overlays. With respect to the overlays, the merge is done in the following order (first used as base):
 * input/resources (generated by the bootstrap script)
 * input/rootfs_overlay_demo 
 * input/my_overlay
2022-09-28 08:52:37 [WARN] [mender-convert-modify] New mender.conf contents after merging: {
  "ServerURL": "https://my-server.com/",
  "ServerCertificate": "/etc/mender/server.crt",
  "foo": "bar"
}
````
I think this is enough info for the user to understand what is going on.

`enable_demo_configuration_in_file` does something very similar which I also believe to be enough:
````
2022-09-28 09:42:06 [INFO] [mender-convert-modify] Adding the demo configuration to the Mender client
2022-09-28 09:42:06 [WARN] [mender-convert-modify] New mender.conf contents: {  
  "ServerURL": "https://my-server.com/",                                                                                                                                                                           
  "ServerCertificate": "/etc/mender/server.crt",                                                         
  "foo": "bar",                                                                                          
  "InventoryPollIntervalSeconds": 5,                                                                     
  "RetryPollIntervalSeconds": 30,                                                                        
  "UpdatePollIntervalSeconds": 5                                                                         
}            
````