### PR TITLE
MEN-5944, MEN-5954 and MEN-5955: Mender integration with latest Raspberry Pi OS images

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -11,8 +11,8 @@ variables:
   MENDER_ADDON_CONFIGURE_VERSION: latest
 
   ## Auto-update
-  RASPBIAN_URL: "https://downloads.raspberrypi.org/raspios_lite_armhf/images/raspios_lite_armhf-2022-01-28/2022-01-28-raspios-bullseye-armhf-lite.zip"
-  RASPBIAN_NAME: 2022-01-28-raspios-bullseye-armhf-lite
+  RASPBIAN_URL: "https://downloads.raspberrypi.org/raspios_lite_armhf/images/raspios_lite_armhf-2022-09-26/2022-09-22-raspios-bullseye-armhf-lite.img.xz"
+  RASPBIAN_NAME: 2022-09-22-raspios-bullseye-armhf-lite
 
   # Which version of mender-convert to use in published image name. Normally
   # empty, in which case the branch or tag name will be used, but this variable
@@ -102,7 +102,7 @@ build:
   tags:
     - mender-qa-slave
   before_script:
-    - apt update && apt install -yy bash wget unzip awscli docker.io curl
+    - apt update && apt install -yy bash wget xz-utils awscli docker.io curl
 
     - export IMAGE_NAME=$DOCKER_REPOSITORY:pr
     - docker load -i image.tar
@@ -110,7 +110,7 @@ build:
     - mkdir -p input
     - cd input
     - wget -q ${RASPBIAN_URL}
-    - unzip ${RASPBIAN_NAME}.zip
+    - unxz ${RASPBIAN_NAME}.img.xz
     - cd ..
 
     - eval "$(curl https://raw.githubusercontent.com/mendersoftware/mendertesting/master/mender-ci-common.sh)"

--- a/configs/raspberrypi_config
+++ b/configs/raspberrypi_config
@@ -92,11 +92,24 @@ function platform_modify() {
         run_and_log_cmd "sudo ln -fs /uboot/${f} work/rootfs/boot/${f}"
     done
 
-    # Raspberry Pi headless configuration expects boot partition to be mounted
-    # at /boot, so replace these services with /uboot
-    run_and_log_cmd "find work/rootfs/lib/ -type f -name *.service | xargs sed -i.bak 's|/boot/|/uboot/|g'"
-    log_debug "Diff from modified service files:\n$(find work/rootfs/lib/ -type f -name '*.service' | xargs -I@ bash -c 'diff -u @.bak @')"
-    run_and_log_cmd "find work/rootfs/lib/ -type f -name *.service.bak | xargs rm"
+    # Raspberry Pi headless configuration and other first boot scripts inspect the boot partition
+    # for files. Modify the hard-coded mount point for the partition from /boot to /uboot.
+
+    # Integrate with systemd services with "/boot/" hardcoded
+    files_to_modify=$(find work/rootfs/lib/ -type f -name "*.service" | xargs grep '/boot/' | cut -d: -f1 | uniq)
+
+    # MEN-5944: Integrate with raspberrypi-sys-mods/firstboot
+    # See: https://github.com/RPi-Distro/raspberrypi-sys-mods
+    if [ -f "work/rootfs/usr/lib/raspberrypi-sys-mods/firstboot" ]; then
+        files_to_modify="$files_to_modify work/rootfs/usr/lib/raspberrypi-sys-mods/firstboot"
+    fi
+
+    # Modify the files and log the changes
+    for f in $files_to_modify; do
+        run_and_log_cmd "sed -i.bak 's|/boot|/uboot|g' ${f}"
+        log_debug "Modified file ${f}\n$(diff -u ${f}.bak ${f})"
+        rm ${f}.bak
+    done
     log_info "Certain service files have been changed to align with our /uboot boot partition mount point. See convert.log for more information"
 
     run_and_log_cmd "sudo install -m 755 work/rpi/binaries/fw_printenv work/rootfs/sbin/fw_printenv"

--- a/configs/raspberrypi_config
+++ b/configs/raspberrypi_config
@@ -104,6 +104,12 @@ function platform_modify() {
         files_to_modify="$files_to_modify work/rootfs/usr/lib/raspberrypi-sys-mods/firstboot"
     fi
 
+    # MEN-5954: Integrate with userconf-pi/userconf-service
+    # See: https://github.com/RPi-Distro/userconf-pi
+    if [ -f "work/rootfs/usr/lib/userconf-pi/userconf-service" ]; then
+        files_to_modify="$files_to_modify work/rootfs/usr/lib/userconf-pi/userconf-service"
+    fi
+
     # Modify the files and log the changes
     for f in $files_to_modify; do
         run_and_log_cmd "sed -i.bak 's|/boot|/uboot|g' ${f}"

--- a/configs/raspberrypi_config
+++ b/configs/raspberrypi_config
@@ -110,6 +110,12 @@ function platform_modify() {
         files_to_modify="$files_to_modify work/rootfs/usr/lib/userconf-pi/userconf-service"
     fi
 
+    # MEN-5955: Integrate with raspberrypi-net-mods/wpa_copy
+    # See: https://github.com/RPi-Distro/raspberrypi-net-mods
+    if [ -f "work/rootfs/usr/lib/raspberrypi-net-mods/wpa_copy" ]; then
+        files_to_modify="$files_to_modify work/rootfs/usr/lib/raspberrypi-net-mods/wpa_copy"
+    fi
+
     # Modify the files and log the changes
     for f in $files_to_modify; do
         run_and_log_cmd "sed -i.bak 's|/boot|/uboot|g' ${f}"

--- a/scripts/test/run-tests.sh
+++ b/scripts/test/run-tests.sh
@@ -36,7 +36,7 @@ BBB_DEBIAN_SDCARD_IMAGE_URL="https://debian.beagleboard.org/images/bone-debian-1
 BBB_DEBIAN_EMMC_IMAGE_URL="https://rcn-ee.com/rootfs/bb.org/testing/2022-03-02/buster-console/bone-debian-10.11-console-armhf-2022-03-02-1gb.img.xz"
 
 ## Auto-update
-RASPBIAN_IMAGE_URL="http://downloads.raspberrypi.org/raspbian_lite/images/raspbian_lite-2020-02-14/2020-02-13-raspbian-buster-lite.zip"
+RASPBIAN_IMAGE_URL="https://downloads.raspberrypi.org/raspios_lite_armhf/images/raspios_lite_armhf-2022-09-26/2022-09-22-raspios-bullseye-armhf-lite.img.xz"
 
 UBUNTU_IMAGE_URL="https://downloads.mender.io/mender-convert/images/Ubuntu-Focal-x86-64.img.gz"
 


### PR DESCRIPTION
`$ changelog-generator --repo master..HEAD`
### Changelogs

#### mender-convert (HEAD)

New changes in mender-convert since master:

##### Bug Fixes

* Support Mender integration in
  `raspberrypi-sys-mods/firstboot` script included in recent Raspberry Pi
  OS images by modifying the hard-coded mount point for the boot partition
  from  `/boot` to `/uboot`.
  ([MEN-5944](https://tracker.mender.io/browse/MEN-5944))
* Support Mender integration in `userconf-pi/userconf-service`
  script included in recent Raspberry Pi OS images by modifying the
  hard-coded mount point for the boot partition from  `/boot` to `/uboot`.
  ([MEN-5954](https://tracker.mender.io/browse/MEN-5954))
* Support Mender integration in
  `raspberrypi-net-mods/wpa_copy` script included in recent Raspberry Pi
  OS images by modifying the hard-coded mount point for the boot partition
  from  `/boot` to `/uboot`.
  ([MEN-5955](https://tracker.mender.io/browse/MEN-5955))
