### PR TITLE
chore: Update mender-image-tests

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -174,6 +174,9 @@ convert_raspbian_raspberrypi4:
     # Python3 dependencies
     - python3 -m pip install -U pip
     - pip3 install --ignore-installed -r https://raw.githubusercontent.com/mendersoftware/meta-mender/master/tests/acceptance/requirements_py3.txt
+    # Manually installing redo because it is not (yet) in meta-mender requirements
+    # To be removed with https://tracker.mender.io/browse/QA-464
+    - pip3 install redo
     # Load image under test
     - export IMAGE_NAME=$DOCKER_REPOSITORY:pr
     - docker load -i image.tar


### PR DESCRIPTION
To bring an stability fix for helpers.install_update