### PR TITLE
chore: Update mender-image-tests

### DIFF
--- a/tests/requirements_py3.txt
+++ b/tests/requirements_py3.txt
@@ -21,6 +21,7 @@ pytest-html==3.1.1
 pytest-metadata==2.0.2
 python-lzo==1.14
 PyYAML==6.0
+redo==2.0.4
 requests==2.28.1
 six==1.16.0
 toml==0.10.2


### PR DESCRIPTION
To bring an stability fix for helpers.install_update