### PR TITLE
fix: Fix grub.d integration on architecture cross-build

### DIFF
--- a/modules/grub.sh
+++ b/modules/grub.sh
@@ -111,9 +111,10 @@ function grub_install_grub_d_config() {
     # build. Instead, use `--removable`, which creates entries that automate
     # booting if you put the image into a new device, which you almost certainly
     # will after using mender-convert.
-    run_and_log_cmd_noexit "sudo chroot work/rootfs grub-install --removable --no-nvram" || ret=$?
+    local -r target_name=$(probe_grub_install_target)
+    run_and_log_cmd_noexit "sudo chroot work/rootfs grub-install --target=${target_name} --removable --no-nvram" || ret=$?
     if [ $ret -eq 0 ]; then
-        run_and_log_cmd_noexit "sudo chroot work/rootfs grub-install --no-nvram" || ret=$?
+        run_and_log_cmd_noexit "sudo chroot work/rootfs grub-install --target=${target_name} --no-nvram" || ret=$?
     fi
 
     if [ $ret -eq 0 ]; then

--- a/modules/probe.sh
+++ b/modules/probe.sh
@@ -36,8 +36,10 @@ probe_arch() {
     fi
 
     target_arch="unknown"
-    if grep -q x86-64 <<< "${file_info}"; then
+    if grep -Eq "ELF 64-bit.*x86-64" <<< "${file_info}"; then
         target_arch="x86_64"
+    elif grep -Eq "ELF 32-bit.*386" <<< "${file_info}"; then
+        target_arch="i386"
     elif grep -Eq "ELF 32-bit.*ARM" <<< "${file_info}"; then
         target_arch="arm"
     elif grep -Eq "ELF 64-bit.*aarch64" <<< "${file_info}"; then
@@ -70,6 +72,27 @@ probe_grub_efi_name() {
             ;;
     esac
     echo "$efi_name"
+}
+
+# Prints GRUB grub-install target name depending on target architecture
+#
+# No input parameters and these work on the assumption that boot and root parts
+# are mounted at work/boot and work/rootfs
+probe_grub_install_target() {
+    local target_name=""
+    local -r arch=$(probe_arch)
+    case "${arch}" in
+        "x86_64")
+            target_name="x86_64-efi"
+            ;;
+        "i386")
+            target_name="i386-efi"
+            ;;
+        *)
+            log_fatal "Unsupported arch: ${arch}"
+            ;;
+    esac
+    echo "$target_name"
 }
 
 # Prints Debian arch name depending on target architecture


### PR DESCRIPTION
Changelog: Fix grub.d integration when host and target 32/64 bit architectures don't match. Namely: pass the correct `--target` parameter to `grub-install` command instead of relaying on host architecture.

Ticket: MEN-5979