### PR TITLE
fix(deb-handling): Correct typo pacakge to package

### DIFF
--- a/mender-convert-modify
+++ b/mender-convert-modify
@@ -102,7 +102,7 @@ log_info "Installing Mender client and related files"
 
 if [ "${MENDER_CLIENT_INSTALL}" = "y" ]; then
     log_info "Installing Mender client version ${MENDER_CLIENT_VERSION}"
-    deb_get_and_install_pacakge mender-client "${MENDER_CLIENT_VERSION}"
+    deb_get_and_install_package mender-client "${MENDER_CLIENT_VERSION}"
 
     # Save installed client version for tests in Yocto variable format
     testscfg_add "PREFERRED_VERSION:mender-client" "$(echo ${DEB_NAME} | sed -r 's/.*_([0-9]+\.[0-9]+\.[0-9]+).*/\1/')"
@@ -115,7 +115,7 @@ fi
 
 if [ "${MENDER_ADDON_CONNECT_INSTALL}" = "y" ]; then
     log_info "Installing Mender Connect addon"
-    deb_get_and_install_pacakge mender-connect "${MENDER_ADDON_CONNECT_VERSION}"
+    deb_get_and_install_package mender-connect "${MENDER_ADDON_CONNECT_VERSION}"
 
     run_and_log_cmd "sudo ln -sf /lib/systemd/system/mender-connect.service \
         work/rootfs/etc/systemd/system/multi-user.target.wants/mender-connect.service"
@@ -123,7 +123,7 @@ fi
 
 if [ "${MENDER_ADDON_CONFIGURE_INSTALL}" = "y" ]; then
     log_info "Installing Mender Configure addon"
-    deb_get_and_install_pacakge mender-configure "${MENDER_ADDON_CONFIGURE_VERSION}" "true"
+    deb_get_and_install_package mender-configure "${MENDER_ADDON_CONFIGURE_VERSION}" "true"
 fi
 
 # Do this unconditionally even if not installing add-ons. The reason is that if

--- a/modules/deb.sh
+++ b/modules/deb.sh
@@ -127,9 +127,9 @@ function deb_extract_package()  {
 #  $2 - Package version
 #  $3 - Arch independent (optional, default "false")
 #
-function deb_get_and_install_pacakge() {
+function deb_get_and_install_package() {
     if ! [[ $# -eq 2 || $# -eq 3 ]]; then
-        log_fatal "deb_get_and_install_pacakge() requires 2 or 3 arguments"
+        log_fatal "deb_get_and_install_package() requires 2 or 3 arguments"
     fi
     local package="$1"
     local version="$2"


### PR DESCRIPTION
Typo fix of the word pacakge.

Changelog: None
Ticket: None

Signed-off-by: Sven Bachmann <dev@mcbachmann.de>