### PR TITLE
fix: Update to grub-mender-grubenv with lock fix.

### DIFF
--- a/configs/mender_grub_config
+++ b/configs/mender_grub_config
@@ -26,7 +26,7 @@ GRUB_VERSION=2.04
 MENDER_GRUB_KERNEL_BOOT_ARGS=""
 
 # grub-mender-grubenv is the Mender integration for the GRUB bootloader
-MENDER_GRUBENV_VERSION="081c20bc7e047c6cd381e39919bdfbdd34f48849"
+MENDER_GRUBENV_VERSION="237750780c518043603b73a911b4a6de076c0437"
 MENDER_GRUBENV_URL="${MENDER_GITHUB_ORG}/grub-mender-grubenv/archive/${MENDER_GRUBENV_VERSION}.tar.gz"
 
 # Name of the storage device containing root filesystem partitions in GRUB


### PR DESCRIPTION
Changelog: grub-mender-grubenv: Add lock file to prevent data races
when accessing boot environment concurrently.

Ticket: None

Signed-off-by: Kristian Amlie <kristian.amlie@northern.tech>