### PR TITLE
Project can now be used as a git submodule again

### DIFF
--- a/docker-mender-convert
+++ b/docker-mender-convert
@@ -52,6 +52,7 @@ docker run \
   -v /lib/modules:/lib/modules:ro \
   --env MENDER_ARTIFACT_NAME="${MENDER_ARTIFACT_NAME}" \
   --env MENDER_CONVERT_LOG_FILE=logs/"${LOG_FILE}" \
+  --env MENDER_CONVERT_VERSION=${GIT_PROVIDED_TAG_NAME} \
   "$IMAGE_NAME" "$@"
 
 exit_code=$?


### PR DESCRIPTION

- Issue: #MEN-6305

To be able to use mender-convert as a git submodule its version needs passing in as the docker environment does not have access to the parent project to be able to traverse to get latest tag information

This is a fix for a previous regression

  Changelog: title

Signed-off-by: Dell Green <dell.green@ideaworks.co.uk>


# External Contributor Checklist

🚨 Please review the [guidelines for contributing](https://github.com/mendersoftware/mender/blob/master/CONTRIBUTING.md) to this repository.

- [x] Make sure that all commits follow the conventional commit [specification](https://www.github.com/mendersoftware/mendertesting/commitlint/grammar.md) for the Mender project.

The majority of our contributions are fixes, which means your commit should have
the form below:

```
fix: <SHORT DESCRIPTION OF FIX>

<OPTIONAL LONGER DESCRIPTION>

Changelog: <USER-FRIENDLY-CHANGE-DESCRIPTION> or <None>
Ticket: <TICKET NUMBER> or <None>
```

- [x] Make sure that all commits are signed with [`git --signoff`](https://git-scm.com/book/en/v2/Git-Tools-Signing-Your-Work). Also note that the signoff author must match the author of the commit.

### Description

Please describe your pull request.

Thank you!
