### PR TITLE
Add support for installing mender client for ubuntu jammy conversions

### DIFF
--- a/configs/mender_convert_config
+++ b/configs/mender_convert_config
@@ -155,7 +155,7 @@ MENDER_APT_REPO_URL="${MENDER_STORAGE_URL}/repos/debian"
 
 # Mender APT repo available distributions, do not modify this unless you know
 # what you are doing.
-MENDER_APT_REPO_DISTS="debian/buster debian/bullseye ubuntu/bionic ubuntu/focal"
+MENDER_APT_REPO_DISTS="debian/buster debian/bullseye ubuntu/bionic ubuntu/focal ubuntu/jammy"
 
 # Mender GitHub organization URL prefix
 MENDER_GITHUB_ORG="https://github.com/mendersoftware"


### PR DESCRIPTION
Ubuntu Jammy mender-client deb packages are available upstream, without this update mender-convert fails to find upstream client deb package to install when converting a Ubuntu jammy disk image.

Changelog: Added support for installing mender client for Ubuntu jammy conversions
Ticket: #MEN-6306

Signed-off-by: Dell Green <dell.green@ideaworks.co.uk>


# External Contributor Checklist

🚨 Please review the [guidelines for contributing](https://github.com/mendersoftware/mender/blob/master/CONTRIBUTING.md) to this repository.

- [x] Make sure that all commits follow the conventional commit [specification](https://www.github.com/mendersoftware/mendertesting/commitlint/grammar.md) for the Mender project.

The majority of our contributions are fixes, which means your commit should have
the form below:

```
fix: <SHORT DESCRIPTION OF FIX>

<OPTIONAL LONGER DESCRIPTION>

Changelog: <USER-FRIENDLY-CHANGE-DESCRIPTION> or <None>
Ticket: <TICKET NUMBER> or <None>
```

- [x] Make sure that all commits are signed with [`git --signoff`](https://git-scm.com/book/en/v2/Git-Tools-Signing-Your-Work). Also note that the signoff author must match the author of the commit.

### Description

Please describe your pull request.

Thank you!
