### PR TITLE
Support mender deb package data archive zstandard compression

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,6 +17,7 @@ RUN apt-get update && env DEBIAN_FRONTEND=noninteractive apt-get install -y \
 # For 'ar' command to unpack .deb
     binutils \
     xz-utils \
+    zstd \
 # to be able to detect file system types of extracted images
     file \
 # to copy files between rootfs directories

--- a/modules/deb.sh
+++ b/modules/deb.sh
@@ -1,4 +1,4 @@
-# Copyright 2022 Northern.tech AS
+# Copyright 2023 Northern.tech AS
 #
 #    Licensed under the Apache License, Version 2.0 (the "License");
 #    you may not use this file except in compliance with the License.
@@ -111,7 +111,10 @@ function deb_extract_package()  {
     cd ${extract_dir}
     run_and_log_cmd "ar -xv ${deb_package}"
     mkdir -p files
-    run_and_log_cmd "sudo tar xJf data.tar.xz -C files"
+
+    local -r data_archive=$(find . -maxdepth 1 -type f -regex '.*/data\.tar\.\(zst\|xz\)'  -printf '%P\n' -quit)
+    run_and_log_cmd "sudo tar xf ${data_archive} -C files"
+
     cd - > /dev/null 2>&1
 
     run_and_log_cmd "sudo rsync --archive --keep-dirlinks --verbose ${extract_dir}/files/ ${dest_dir}"


### PR DESCRIPTION
Newer upstream mender-client deb packages are using zstd compression for the data tar archive. Up until now there was only support for xz compression. Added additional support so that the data archive can be either xz or zstd compressed.

Changelog: support added for mender-client deb package data archive compressed with zstd
Ticket: #MEN-6307

Signed-off-by: Dell Green <dell.green@ideaworks.co.uk>


# External Contributor Checklist

🚨 Please review the [guidelines for contributing](https://github.com/mendersoftware/mender/blob/master/CONTRIBUTING.md) to this repository.

- [x] Make sure that all commits follow the conventional commit [specification](https://www.github.com/mendersoftware/mendertesting/commitlint/grammar.md) for the Mender project.

The majority of our contributions are fixes, which means your commit should have
the form below:

```
fix: <SHORT DESCRIPTION OF FIX>

<OPTIONAL LONGER DESCRIPTION>

Changelog: <USER-FRIENDLY-CHANGE-DESCRIPTION> or <None>
Ticket: <TICKET NUMBER> or <None>
```

- [x] Make sure that all commits are signed with [`git --signoff`](https://git-scm.com/book/en/v2/Git-Tools-Signing-Your-Work). Also note that the signoff author must match the author of the commit.

### Description

Please describe your pull request.

Thank you!
