### PR TITLE
QA-554: Update to Ubuntu 22.04 Jammy and fix test.

### DIFF
--- a/configs/ubuntu-qemux86-64_config
+++ b/configs/ubuntu-qemux86-64_config
@@ -8,11 +8,11 @@
 #
 # Locally, converted with the following command:
 #
-#    MENDER_ARTIFACT_NAME=release-1 ./docker-mender-convert --disk-image input/Ubuntu-Focal-x86-64.img --overlay rootfs_overlay_demo --config configs/qemux86-64_config
+#    MENDER_ARTIFACT_NAME=release-1 ./docker-mender-convert --disk-image input/Ubuntu-Jammy-x86-64.img --config configs/ubuntu-qemux86-64_config
 #
 # and qemu is executed with the following command:
 #
-#    qemu-system-x86_64 -enable-kvm -m 512 -smp 2 -bios /usr/share/OVMF/OVMF_CODE.fd -drive format=raw,file=deploy/Ubuntu-Focal-x86-64-qemux86-64-mender.img
+#    qemu-system-x86_64 -enable-kvm -m 512 -smp 2 -bios /usr/share/OVMF/OVMF_CODE.fd -drive format=raw,file=deploy/Ubuntu-Jammy-x86-64-qemux86-64-mender.img
 
 MENDER_STORAGE_DEVICE_BASE=/dev/sda
 MENDER_DEVICE_TYPE="qemux86-64"

--- a/scripts/test/generate-image.sh
+++ b/scripts/test/generate-image.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Copyright 2022 Northern.tech AS
+# Copyright 2023 Northern.tech AS
 #
 #    Licensed under the Apache License, Version 2.0 (the "License");
 #    you may not use this file except in compliance with the License.
@@ -25,6 +25,12 @@ if [ "$UID" -ne 0 ]; then
     echo "We'll need root for this..." 1>&2
     exec sudo "$0" "$@"
 fi
+
+DEBIAN_CODENAME="bullseye"
+DEBIAN_IMAGE_ID="Debian-11"
+
+UBUNTU_CODENAME="jammy"
+UBUNTU_IMAGE_ID="Ubuntu-Jammy"
 
 while [ -n "$1" ]; do
     case "$1" in
@@ -53,9 +59,9 @@ cleanup_losetup() {
 }
 
 generate_debian() {
-    local -r image="Debian-11-x86-64.img"
+    local -r image="${DEBIAN_IMAGE_ID}-x86-64.img"
 
-    mkosi --root-size=2G --distribution=debian --release=bullseye --format=gpt_ext4 --bootable --checksum \
+    mkosi --root-size=2G --distribution=debian --release="$DEBIAN_CODENAME" --format=gpt_ext4 --bootable --checksum \
           --password password --package=openssh-server,dhcpcd5 --package grub-efi-amd64-signed \
           --package shim-signed --package lsb-release --output="$image" build
 
@@ -65,9 +71,9 @@ generate_debian() {
 }
 
 generate_ubuntu() {
-    local -r image="Ubuntu-Focal-x86-64.img"
+    local -r image="${UBUNTU_IMAGE_ID}-x86-64.img"
 
-    mkosi --root-size=2G --distribution=ubuntu --release=focal --format=gpt_ext4 --bootable --checksum \
+    mkosi --root-size=2G --distribution=ubuntu --release="$UBUNTU_CODENAME" --format=gpt_ext4 --bootable --checksum \
           --password password --package=openssh-server,dhcpcd5 --package grub-efi-amd64-signed \
           --package shim-signed --package lsb-release --output="$image" build
 

--- a/scripts/test/run-tests.sh
+++ b/scripts/test/run-tests.sh
@@ -38,7 +38,7 @@ BBB_DEBIAN_EMMC_IMAGE_URL="https://rcn-ee.com/rootfs/bb.org/testing/2022-03-02/b
 ## Auto-update
 RASPBIAN_IMAGE_URL="https://downloads.raspberrypi.org/raspios_lite_armhf/images/raspios_lite_armhf-2022-09-26/2022-09-22-raspios-bullseye-armhf-lite.img.xz"
 
-UBUNTU_IMAGE_URL="https://downloads.mender.io/mender-convert/images/Ubuntu-Focal-x86-64.img.gz"
+UBUNTU_IMAGE_URL="https://downloads.mender.io/mender-convert/images/Ubuntu-Jammy-x86-64.img.gz"
 
 DEBIAN_IMAGE_URL="https://downloads.mender.io/mender-convert/images/Debian-11-x86-64.img.gz"
 
@@ -109,7 +109,7 @@ else
     sudo cp -r "tests/ssh-public-key-overlay" "input/tests/"
     convert_and_test "qemux86-64" \
                      "release-1" \
-                     "input/image/Ubuntu-Focal-x86-64.img.gz" \
+                     "input/image/Ubuntu-Jammy-x86-64.img.gz" \
                      "--overlay input/tests/ssh-public-key-overlay" \
                      "--config configs/ubuntu-qemux86-64_config $EXTRA_CONFIG" \
                      "--" \
@@ -120,13 +120,13 @@ else
     echo >&2 "Running the uncompressed test"
     echo >&2 "----------------------------------------"
     rm -rf deploy
-    gunzip --force "input/image/Ubuntu-Focal-x86-64.img.gz"
+    gunzip --force "input/image/Ubuntu-Jammy-x86-64.img.gz"
     run_convert "release-2" \
-                "input/image/Ubuntu-Focal-x86-64.img" \
+                "input/image/Ubuntu-Jammy-x86-64.img" \
                 "--config configs/ubuntu-qemux86-64_config $EXTRA_CONFIG" || test_result=$?
     ret=0
-    test -f deploy/Ubuntu-Focal-x86-64-qemux86-64-mender.img || ret=$?
-    assert "${ret}" "0" "Expected uncompressed file deploy/Ubuntu-Focal-x86-64-qemux86-64-mender.img"
+    test -f deploy/Ubuntu-Jammy-x86-64-qemux86-64-mender.img || ret=$?
+    assert "${ret}" "0" "Expected uncompressed file deploy/Ubuntu-Jammy-x86-64-qemux86-64-mender.img"
   fi
 
   if [ "$TEST_ALL" == "1" -o "$TEST_PLATFORM" == "ubuntu-qemux86-64-no-grub-d" ]; then
@@ -137,7 +137,7 @@ else
                      convert_and_test \
                      "qemux86-64" \
                      "release-1" \
-                     "input/image/Ubuntu-Focal-x86-64.img.gz" \
+                     "input/image/Ubuntu-Jammy-x86-64.img.gz" \
                      "--overlay input/tests/ssh-public-key-overlay" \
                      "--config configs/ubuntu-qemux86-64_config" \
                      "--config configs/testing/no-grub.d_config $EXTRA_CONFIG" \


### PR DESCRIPTION
```
commit 0623c4cd1877a23e18c3c5157575dfd422a0d024
Author: Kristian Amlie <kristian.amlie@northern.tech>
Date:   Fri Feb 24 14:34:03 2023

    test: Ignore some grub.cfg differences in `00_header` section.
    
    Ubuntu 22.04 Jammy can trigger differences in searching for the root
    device when running live as opposed to mender-convert's jailroot.
    Since we have grub scripts which later set root back to the value it
    should be, it is safe to ignore these differences. However, since it
    is dangerous to ignore these differences *outside* `00_header`, make
    the sed script fairly specific so that it is only ignored inside this
    section.
    
    Ticket: QA-554
    
    Signed-off-by: Kristian Amlie <kristian.amlie@northern.tech>

commit c4bd09a03a675b8ac56ba960e8cd74d74dd81f34
Author: Lluis Campos <lluis.campos@northern.tech>
Date:   Thu Feb 16 09:14:48 2023

    chore: Update Ubuntu test image to Jammy distribution
    
    Ticket: QA-554
    
    Signed-off-by: Lluis Campos <lluis.campos@northern.tech>
```