### PR TITLE
fix(grub-mender-grubenv): Boot failure because of missing storage.

### DIFF
--- a/configs/mender_grub_config
+++ b/configs/mender_grub_config
@@ -26,7 +26,7 @@ GRUB_VERSION=2.04
 MENDER_GRUB_KERNEL_BOOT_ARGS=""
 
 # grub-mender-grubenv is the Mender integration for the GRUB bootloader
-MENDER_GRUBENV_VERSION="eeb7ebd9e6558cf6bbe661b4f2e4e45d52efa305"
+MENDER_GRUBENV_VERSION="a525df022c10950ddbadad05adaefe7b2451ec62"
 MENDER_GRUBENV_URL="${MENDER_GITHUB_ORG}/grub-mender-grubenv/archive/${MENDER_GRUBENV_VERSION}.tar.gz"
 
 # Name of the storage device containing root filesystem partitions in GRUB


### PR DESCRIPTION
Changelog: Fix boot failure because `mender_grub_storage_device` is not exported correctly.

Ticket: None
