### PR TITLE
fix: Remove trailing forward slash in overlay path.

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,7 +162,7 @@ MENDER_ARTIFACT_NAME=release-1 ./docker-mender-convert \
    --disk-image input/image/$INPUT_DISK_IMAGE \
    --config configs/raspberrypi3_config \
    --config input/config/$CUSTOM_CONFIG \
-   --overlay rootfs_overlay_demo/
+   --overlay rootfs_overlay_demo
 ```
 
 The container will use the `work/` directory as a temporary area to unpack and
@@ -194,7 +194,7 @@ Start the conversion process with:
 MENDER_ARTIFACT_NAME=release-1 ./mender-convert \
    --disk-image input/$INPUT_DISK_IMAGE \
    --config configs/raspberrypi3_config \
-   --overlay rootfs_overlay_demo/
+   --overlay rootfs_overlay_demo
 ```
 
 **NOTE!** You will be prompted to enter `sudo` password during the conversion


### PR DESCRIPTION
This prevented the overlay from being applied, due to duplicate slashes in the rsync command (mender-convert-modify line 280). The end result was that the /etc/mender/mender.conf file was missing from the final image. Removing the extra forward slash solved the problem.

Changelog: Commit
Ticket: None
Signed-off-by: Tom Callahan <78968887+tcallahan14@users.noreply.github.com>
(cherry picked from commit b338790a76513973941133f8dd97375abf0b31de)
