### PR TITLE
feat: Add support for operating on squashfs files

### DIFF
--- a/mender-convert-package
+++ b/mender-convert-package
@@ -370,6 +370,9 @@ case "${MENDER_COMPRESS_DISK_IMAGE}" in
     none)
         :
         ;;
+    sqfs)
+        :
+        ;;
     *)
         log_fatal "Unknown MENDER_COMPRESS_DISK_IMAGE value: ${MENDER_COMPRESS_DISK_IMAGE}"
         ;;

--- a/modules/decompressinput.sh
+++ b/modules/decompressinput.sh
@@ -39,6 +39,9 @@ function compression_type()  {
         *.xz)
             echo "lzma"
             ;;
+        *.sqsh)
+            echo "sqfs"
+            ;;
         *)
             log_fatal "Unsupported compression type: ${disk_image}. Please uncompress the image yourself."
             ;;
@@ -78,6 +81,16 @@ function decompress_image()  {
             log_info "Decompressing ${disk_image}..."
             disk_image=${disk_image%.xz}
             xzcat "${input_image}" > "${disk_image}"
+            ;;
+        sqfs)
+            log_info "mounting squashfs"
+            disk_image=${disk_image%.sqsh}
+            mount_squash=$(mktemp -d)
+            sudo mount -o loop -t squashfs "${input_image}" "$mount_squash"
+            sudo touch "${disk_image}"
+            sudo mount -o ro,bind "$mount_squash/disk.img" "${disk_image}"
+            
+            UMOUNTS_LIST+=("$disk_image" "$mount_squash")
             ;;
         *)
             log_fatal "Unsupported input image format: ${input_image}. We support: '.img', '.gz', '.zip', '.xz'."


### PR DESCRIPTION
### Motivation
By creating the disk image directly into a squash file system [^1] and then bind mounting the image onto a file in the input directory we can save a significant amount of space, especially for larger input images

### Potential issue
partx, which is used to get partition information in mender-convert-extract generates error messages on stderr since the disk image is read only, however the correct output is generated on stdout and the commands exit with 0 exit code

### Example
I'm using a golden device with a disk size of 120GB, the rootfs partition is 60GB of which 35-40 are used. The squashfs image obtained by dd-ing the whole disk is 24GB without requiring manual alterations of the partition table and filesystems after creating the golden image

[^1]: By using dd in combination with [the command in this article](https://semjonov.de/posts/2021-05/create-squashfs-archive-from-stdin-and-sign-it-on-the-fly/)