### PR TITLE
feat: add support for BTRFS filesystems

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,6 +29,8 @@ RUN apt-get update && env DEBIAN_FRONTEND=noninteractive apt-get install -y \
     e2fsprogs \
 # mkfs.xfs and family
     xfsprogs \
+# mkfs.btrfs and family
+    btrfs-progs \
 # Parallel gzip compression
     pigz \
     sudo \

--- a/mender-convert-package
+++ b/mender-convert-package
@@ -200,8 +200,10 @@ if file ${root_part} | grep -q ext4; then
     image_fs_type="ext4"
 elif file ${root_part} | grep -q XFS; then
     image_fs_type="xfs"
+elif file ${root_part} | grep -q BTRFS; then
+    image_fs_type="btrfs"
 else
-    log_warn "$(file work/${root_part})"
+    log_warn "$(file ${root_part})"
     log_fatal "Could not determine root file-system type. Aborting..."
 fi
 

--- a/modules/disk.sh
+++ b/modules/disk.sh
@@ -134,6 +134,15 @@ disk_create_file_system_from_folder() {
             fi
             run_and_log_cmd "${MKFS_XFS} -q -f ${2} ${EXTRA_OPTS}"
             ;;
+
+        "btrfs")
+            MKFS_BTRFS="/usr/bin/mkfs.btrfs"
+            if [ ! -f ${MKFS_BTRFS} ]; then
+                MKFS_BTRFS="/usr/sbin/mkfs.btrfs"
+            fi
+            run_and_log_cmd "${MKFS_BTRFS} -q -f ${2} ${EXTRA_OPTS}"
+            ;;
+
         *)
             log_fatal "Unknown file system type specified: ${4}"
             ;;


### PR DESCRIPTION
When trying to integrate Mender in an Uboard (x86_64) with Ubuntu Server, I have noticed that there was no support for BTRFS filesystems, so here it is!