### PR TITLE
fix: Direct download of deb binary packages with different source package name

### DIFF
--- a/mender-convert-modify
+++ b/mender-convert-modify
@@ -104,7 +104,7 @@ if [ "${MENDER_CLIENT_INSTALL}" = "y" ]; then
     case "${MENDER_CLIENT_VERSION}" in
         1.* | 2.* | 3.*)
             log_info "Installing Mender client version ${MENDER_CLIENT_VERSION}"
-            deb_get_and_install_package mender-client "${MENDER_CLIENT_VERSION}"
+            deb_get_and_install_package mender-client mender-client "${MENDER_CLIENT_VERSION}"
             mender_client_deb_name="${DEB_NAME}"
             ;;
         *)
@@ -112,12 +112,12 @@ if [ "${MENDER_CLIENT_INSTALL}" = "y" ]; then
             # At the time of writing, this will be broken for "latest" until mender-client v4 is
             # released. Having an special handling deemed to complex for the short time benefit.
             log_info "Installing Mender Auth and Mender Update version ${MENDER_CLIENT_VERSION}"
-            deb_get_and_install_package mender-auth "${MENDER_CLIENT_VERSION}"
-            deb_get_and_install_package mender-update "${MENDER_CLIENT_VERSION}"
+            deb_get_and_install_package mender-client mender-auth "${MENDER_CLIENT_VERSION}"
+            deb_get_and_install_package mender-client mender-update "${MENDER_CLIENT_VERSION}"
             mender_client_deb_name="${DEB_NAME}"
 
             log_info "Installing Mender Flash version ${MENDER_FLASH_VERSION}"
-            deb_get_and_install_package mender-flash "${MENDER_FLASH_VERSION}"
+            deb_get_and_install_package mender-flash mender-flash "${MENDER_FLASH_VERSION}"
             ;;
     esac
 
@@ -142,7 +142,7 @@ fi
 
 if [ "${MENDER_ADDON_CONNECT_INSTALL}" = "y" ]; then
     log_info "Installing Mender Connect addon"
-    deb_get_and_install_package mender-connect "${MENDER_ADDON_CONNECT_VERSION}"
+    deb_get_and_install_package mender-connect mender-connect "${MENDER_ADDON_CONNECT_VERSION}"
 
     run_and_log_cmd "sudo ln -sf /lib/systemd/system/mender-connect.service \
         work/rootfs/etc/systemd/system/multi-user.target.wants/mender-connect.service"
@@ -150,7 +150,7 @@ fi
 
 if [ "${MENDER_ADDON_CONFIGURE_INSTALL}" = "y" ]; then
     log_info "Installing Mender Configure addon"
-    deb_get_and_install_package mender-configure "${MENDER_ADDON_CONFIGURE_VERSION}" "true"
+    deb_get_and_install_package mender-configure mender-configure "${MENDER_ADDON_CONFIGURE_VERSION}" "true"
 fi
 
 # Do this unconditionally even if not installing add-ons. The reason is that if

--- a/modules/deb.sh
+++ b/modules/deb.sh
@@ -62,23 +62,21 @@ function deb_from_repo_dist_get()  {
 #  $3 - Debian architecture
 #  $4 - Package name
 #  $5 - Package version
-#  $6 - Component (optional, default "main")
 #
 # @return - Filename of the downloaded package
 #
 function deb_from_repo_pool_get()  {
-    if [[ $# -lt 5 || $# -gt 7 ]]; then
-        log_fatal "deb_from_repo_pool_get() requires 5 arguments. 6th is optional"
+    if [[ $# -ne 5 ]]; then
+        log_fatal "deb_from_repo_pool_get() requires 5 arguments"
     fi
     local -r download_dir="${1}"
     local -r repo_url="${2}"
     local -r architecture="${3}"
     local -r package="${4}"
     local -r version="${5}"
-    local -r component="${6:-main}"
 
     local -r initial="$(echo $package | head -c 1)"
-    local -r deb_package_path="pool/${component}/${initial}/${package}/${package}_${version}_${architecture}.deb"
+    local -r deb_package_path="pool/main/${initial}/${package}/${package}_${version}_${architecture}.deb"
 
     local -r filename=$(basename $deb_package_path)
     local -r deb_package_url=$(echo ${repo_url}/${deb_package_path} | sed 's/+/%2B/g')


### PR DESCRIPTION
Up until now we had assumed that the binary package to download had the same name as the source package, but this is not true anymore when `mender-client` source builds `mender-auth` or `mender-update` binary packages.
