### PR TITLE
chore: Update data-dir dependency to work for both Golang and C++ clients.

### DIFF
--- a/mender-convert-modify
+++ b/mender-convert-modify
@@ -192,13 +192,15 @@ if [ "${MENDER_GRUB_EFI_INTEGRATION}" == "y" ]; then
 fi
 
 MENDER_CLIENT_DATA_DIR_SERVICE_URL="https://raw.githubusercontent.com/mendersoftware/\
-meta-mender/e05cde10fde3646a78081709e717fb42a6c5ba44/meta-mender-core/recipes-mender/mender-client/files/mender-client-data-dir.service"
+meta-mender/ab9c1e65abf73cde1065e2a4c2005cfe61ee6e3d/meta-mender-core/recipes-mender/mender-client/files/mender-data-dir.service"
 
-run_and_log_cmd "wget --quiet -O work/mender-client-data-dir.service $MENDER_CLIENT_DATA_DIR_SERVICE_URL"
-run_and_log_cmd "sudo install -m 644 work/mender-client-data-dir.service work/rootfs/lib/systemd/system/mender-client-data-dir.service"
-run_and_log_cmd "sudo mkdir -p work/rootfs/lib/systemd/system/mender-client.service.wants"
-run_and_log_cmd "sudo ln -sf /lib/systemd/system/mender-client-data-dir.service \
-    work/rootfs/lib/systemd/system/mender-client.service.wants/mender-client-data-dir.service"
+run_and_log_cmd "wget --quiet -O work/mender-data-dir.service $MENDER_CLIENT_DATA_DIR_SERVICE_URL"
+run_and_log_cmd "sudo install -m 644 work/mender-data-dir.service work/rootfs/lib/systemd/system/mender-data-dir.service"
+for service_name in mender-client mender-updated; do
+    run_and_log_cmd "sudo mkdir -p work/rootfs/lib/systemd/system/${service_name}.service.wants"
+    run_and_log_cmd "sudo ln -sf /lib/systemd/system/mender-data-dir.service \
+        work/rootfs/lib/systemd/system/${service_name}.service.wants/mender-data-dir.service"
+done
 
 run_and_log_cmd "sudo mkdir -p work/rootfs/data/mender"
 run_and_log_cmd "sudo mkdir -p work/rootfs/var/lib"


### PR DESCRIPTION
Changelog: The `mender-client-data-dir.service` has been renamed to `mender-data-dir.service`. This is used as a dependency for the mender update client, and most users should not notice the change.
