### PR TITLE
chore: Update README, comments and help text after moving overlay

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,5 @@
 deploy
 input
-rootfs_overlay_demo/*
 mender_local_config
 *.xml
 *.html

--- a/README.md
+++ b/README.md
@@ -105,14 +105,14 @@ type you are implementing.
 #### Using the [Mender demo server](https://docs.mender.io/getting-started/on-premise-installation/create-a-test-environment)
 ```bash
 ./scripts/bootstrap-rootfs-overlay-demo-server.sh \
-    --output-dir ${PWD}/rootfs_overlay_demo \
+    --output-dir ${PWD}/input/rootfs_overlay_demo \
     --server-ip 192.168.1.1
 ```
 
 #### Using the [Mender production server](https://docs.mender.io/administration/production-installation)
 ```bash
 ./scripts/bootstrap-rootfs-overlay-production-server.sh \
-    --output-dir ${PWD}/rootfs_overlay_demo \
+    --output-dir ${PWD}/input/rootfs_overlay_demo \
     --server-url https://foobar.mender.io \
     [ --server-cert ~/server.crt ]
 ```
@@ -120,7 +120,7 @@ type you are implementing.
 #### Using [Mender Professional](https://mender.io/products/mender-professional)
 ```bash
 ./scripts/bootstrap-rootfs-overlay-hosted-server.sh \
-    --output-dir ${PWD}/rootfs_overlay_demo \
+    --output-dir ${PWD}/input/rootfs_overlay_demo \
     --tenant-token "Paste token from Mender Professional"
 ```
 
@@ -162,7 +162,7 @@ MENDER_ARTIFACT_NAME=release-1 ./docker-mender-convert \
    --disk-image input/image/$INPUT_DISK_IMAGE \
    --config configs/raspberrypi3_config \
    --config input/config/$CUSTOM_CONFIG \
-   --overlay rootfs_overlay_demo
+   --overlay input/rootfs_overlay_demo
 ```
 
 The container will use the `work/` directory as a temporary area to unpack and
@@ -199,7 +199,7 @@ Start the conversion process with:
 MENDER_ARTIFACT_NAME=release-1 ./mender-convert \
    --disk-image input/$INPUT_DISK_IMAGE \
    --config configs/raspberrypi3_config \
-   --overlay rootfs_overlay_demo
+   --overlay input/rootfs_overlay_demo
 ```
 
 **NOTE!** You will be prompted to enter `sudo` password during the conversion

--- a/configs/debian-qemux86-64_config
+++ b/configs/debian-qemux86-64_config
@@ -8,7 +8,7 @@
 #
 # Locally, converted with the following command:
 #
-#    MENDER_ARTIFACT_NAME=release-1 ./docker-mender-convert --disk-image input/Debian-11-x86-64.img --overlay rootfs_overlay_demo --config configs/qemux86-64_config
+#    MENDER_ARTIFACT_NAME=release-1 ./docker-mender-convert --disk-image input/Debian-11-x86-64.img --overlay input/rootfs_overlay_demo --config configs/qemux86-64_config
 #
 # and qemu is executed with the following command:
 #

--- a/scripts/bootstrap-rootfs-overlay-demo-server.sh
+++ b/scripts/bootstrap-rootfs-overlay-demo-server.sh
@@ -30,7 +30,7 @@ while (("$#")); do
             ;;
         *)
             echo "Sorry but the provided option is not supported: $1"
-            echo "Usage:  $(basename $0) --output-dir <rootfs overlay dir> --server-ip <your server IP address>"
+            echo "Usage:  $(basename $0) --output-dir ./input/rootfs_overlay_demo --server-ip <your server IP address>"
             exit 1
             ;;
     esac

--- a/scripts/bootstrap-rootfs-overlay-production-server.sh
+++ b/scripts/bootstrap-rootfs-overlay-production-server.sh
@@ -34,7 +34,7 @@ while (("$#")); do
             ;;
         *)
             echo "Sorry but the provided option is not supported: $1"
-            echo "Usage:  $(basename $0) --output-dir ./rootfs_overlay_demo --server-url <your server URL> [--server-cert <path to your server.crt file>]"
+            echo "Usage:  $(basename $0) --output-dir ./input/rootfs_overlay_demo --server-url <your server URL> [--server-cert <path to your server.crt file>]"
             exit 1
             ;;
     esac


### PR DESCRIPTION
This is a follow-up from commit effe995, where after Dockerization we moved the overlay demo dir into `input/`.