### PR TITLE
ci(image-bot): Update the create-PR GH action to v5

### DIFF
--- a/.github/workflows/automatically-update-test-links.yml
+++ b/.github/workflows/automatically-update-test-links.yml
@@ -18,7 +18,7 @@ jobs:
 
       - name: Create Pull Request
         id: cpr
-        uses: peter-evans/create-pull-request@v3
+        uses: peter-evans/create-pull-request@v5
         with:
           title: 'Image-Bot: New images available'
           body: |


### PR DESCRIPTION
This is required for the job to work now, considering the Node.js version used previously is outdated.

