### PR TITLE
MEN-6948: Set default `MENDER_CLIENT_VERSION` to 3.5.2

### DIFF
--- a/configs/mender_convert_config
+++ b/configs/mender_convert_config
@@ -125,7 +125,8 @@ MENDER_CLIENT_INSTALL="y"
 # This is used to fetch the correct binaries
 #
 # Valid values are "latest" (default), "master" or a specific version
-MENDER_CLIENT_VERSION="latest"
+# MEN-6948 mender-convert is not yet integrated with latest mender-client 4.0.0
+MENDER_CLIENT_VERSION="3.5.2"
 
 # Mender flash version
 #


### PR DESCRIPTION
Changelog: Set default `MENDER_CLIENT_VERSION` to 3.5.2. `mender-convert` is not yet integrated with upcoming client v4.