### PR TITLE
4.1.x: ci: Set `MENDER_CLIENT_VERSION` to 3.5.2 for ci builds

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -6,7 +6,7 @@ variables:
   # These variables are present elsewhere in the repository too. Make sure to
   # search for and change them too.
   MENDER_ARTIFACT_VERSION: master
-  MENDER_CLIENT_VERSION: latest
+  MENDER_CLIENT_VERSION: 3.5.2
   MENDER_ADDON_CONNECT_VERSION: latest
   MENDER_ADDON_CONFIGURE_VERSION: latest
 


### PR DESCRIPTION
Follow-up from 8471a2229dc0ae5349d49a2ee8e822224616e044

Although in this branch the software is already using 3.5.2 by default, the CI builds use the value from the CI configuration.