### PR TITLE
fix: Remove unneeded and potentially harmful storage assignment.

### DIFF
--- a/configs/mender_grub_config
+++ b/configs/mender_grub_config
@@ -29,10 +29,6 @@ MENDER_GRUB_KERNEL_BOOT_ARGS=""
 MENDER_GRUBENV_VERSION="64e32b01d1bf54784d2a290ad0469c583e843864"
 MENDER_GRUBENV_URL="${MENDER_GITHUB_ORG}/grub-mender-grubenv/archive/${MENDER_GRUBENV_VERSION}.tar.gz"
 
-# Name of the storage device containing root filesystem partitions in GRUB
-# format.
-MENDER_GRUB_STORAGE_DEVICE=hd0
-
 # Type of kernel (bzImage or zImage)
 #
 # mender-convert will try to determine this value on its own, only set this

--- a/modules/grub.sh
+++ b/modules/grub.sh
@@ -24,7 +24,6 @@ function grub_create_grub_config() {
     cat <<- EOF > work/grub-mender-grubenv-${MENDER_GRUBENV_VERSION}/mender_grubenv_defines
 mender_rootfsa_part=${MENDER_ROOTFS_PART_A_NUMBER}
 mender_rootfsb_part=${MENDER_ROOTFS_PART_B_NUMBER}
-mender_grub_storage_device=${MENDER_GRUB_STORAGE_DEVICE}
 kernel_imagetype=kernel
 initrd_imagetype=initrd
 EOF


### PR DESCRIPTION
Defining the `mender_grub_storage_device` variable manually has actually not been needed in grub-mender-grubenv for a long time, because it figures it out on its own using the `root` variable, which GRUB fills in during boot. This works better when storage devices change, like when inserting a USB stick, for example.

Although it is definitely unneeded, it's not entirely clear why it messes with the boot in certain instances, since this assignment should happen before any assignment from `root`. But a user has confirmed that this helped.

Changelog: Remove unneeded `mender_grub_storage_device` assignment which could boot from the wrong device if a USB stick was inserted.

Ticket: CE-321

Signed-off-by: Kristian Amlie <kristian.amlie@northern.tech>
(cherry picked from commit e9f8d29d959af8a9f2af594770e42e1494544b72) (cherry picked from commit 4b313596fec4ddb8eef039433a947a61fd3e10a1)


# External Contributor Checklist

🚨 Please review the [guidelines for contributing](https://github.com/mendersoftware/mender/blob/master/CONTRIBUTING.md) to this repository.

- [ ] Make sure that all commits follow the conventional commit [specification](https://www.github.com/mendersoftware/mendertesting/commitlint/grammar.md) for the Mender project.

The majority of our contributions are fixes, which means your commit should have
the form below:

```
fix: <SHORT DESCRIPTION OF FIX>

<OPTIONAL LONGER DESCRIPTION>

Changelog: <USER-FRIENDLY-CHANGE-DESCRIPTION> or <None>
Ticket: <TICKET NUMBER> or <None>
```

- [ ] Make sure that all commits are signed with [`git --signoff`](https://git-scm.com/book/en/v2/Git-Tools-Signing-Your-Work). Also note that the signoff author must match the author of the commit.

### Description

Please describe your pull request.

Thank you!
