### PR TITLE
feat: add support for `MENDER_CLIENT_VERSION="auto"`

### DIFF
--- a/configs/mender_convert_config
+++ b/configs/mender_convert_config
@@ -124,9 +124,13 @@ MENDER_CLIENT_INSTALL="y"
 #
 # This is used to fetch the correct binaries
 #
-# Valid values are "latest" (default), "master" or a specific version
-# MEN-6948 mender-convert is not yet integrated with latest mender-client 4.0.0
-MENDER_CLIENT_VERSION="3.5.2"
+# Valid values are "auto" (default), "latest", "master" or a specific version
+# If set to "auto" then the Mender Client 4.0 or later will be installed unless
+# the distribution is Ubuntu jammy or older or Debian bullseye or older;
+# the latest Mender 3.x client will be installed in those cases.
+# If set to "latest", it will install the latest version of the Mender Client
+# from the 4.x series.
+MENDER_CLIENT_VERSION="auto"
 
 # Mender flash version
 #

--- a/mender-convert-modify
+++ b/mender-convert-modify
@@ -225,19 +225,32 @@ EOF
 log_info "Installing Mender client and related files"
 
 if [ "${MENDER_CLIENT_INSTALL}" = "y" ]; then
+    mender_client_deb_version="$MENDER_CLIENT_VERSION"
+    if [ "$MENDER_CLIENT_VERSION" = "auto" ]; then
+        deb_distro=$(probe_debian_distro_name)
+        deb_codename=$(probe_debian_distro_codename)
+        if ([ "$deb_distro" = "debian" ] && [ "$deb_codename" = "bullseye" ]) \
+            || ([ "$deb_distro" = "debian" ] && [ "$deb_codename" = "buster" ]) \
+            || ([ "$deb_distro" = "ubuntu" ] && [ "$deb_codename" = "jammy" ]) \
+            || ([ "$deb_distro" = "ubuntu" ] && [ "$deb_codename" = "focal" ]); then
+            MENDER_CLIENT_VERSION="3.5.x"
+            mender_client_deb_version="latest"
+        else
+            MENDER_CLIENT_VERSION="latest"
+            mender_client_deb_version="latest"
+        fi
+    fi
     case "${MENDER_CLIENT_VERSION}" in
         1.* | 2.* | 3.*)
-            log_info "Installing Mender client version ${MENDER_CLIENT_VERSION}"
-            deb_get_and_install_package mender-client mender-client "${MENDER_CLIENT_VERSION}"
+            log_info "Installing Mender client version ${mender_client_deb_version}"
+            deb_get_and_install_package mender-client mender-client "${mender_client_deb_version}"
             mender_client_deb_name="${DEB_NAME}"
             ;;
         *)
             # For 4.x, master and latest(*) install the new packages
-            # At the time of writing, this will be broken for "latest" until mender-client v4 is
-            # released. Having an special handling deemed to complex for the short time benefit.
-            log_info "Installing Mender Auth and Mender Update version ${MENDER_CLIENT_VERSION}"
-            deb_get_and_install_package mender-client mender-auth "${MENDER_CLIENT_VERSION}"
-            deb_get_and_install_package mender-client mender-update "${MENDER_CLIENT_VERSION}"
+            log_info "Installing Mender Auth and Mender Update version ${mender_client_deb_version}"
+            deb_get_and_install_package mender-client mender-auth "${mender_client_deb_version}"
+            deb_get_and_install_package mender-client mender-update "${mender_client_deb_version}"
             mender_client_deb_name="${DEB_NAME}"
 
             log_info "Installing Mender Flash version ${MENDER_FLASH_VERSION}"


### PR DESCRIPTION
Changelog: feat: add support for `MENDER_CLIENT_VERSION="auto"`, which installs the Mender Client 3.x series for Debian bullseye and buster and for Ubuntu jammy and focal, the Mender Client 4.x series for all the other distributions
Ticket: MEN-6976