### PR TITLE
ci: Fix quote typo that was preventing hardware tests to launch

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -487,10 +487,10 @@ test:hardware:acceptance:
     - mv ${RASPBERRYPI_PLATFORM} deploy
     # Run the tests
     - ./scripts/test/run-tests.sh
-      --prebuilt-image
-      raspberrypi4
-      "${RASPBIAN_NAME}-${RASPBERRYPI_PLATFORM}-mender
+      --prebuilt-image raspberrypi4
+      ${RASPBIAN_NAME}-${RASPBERRYPI_PLATFORM}-mender
       --
       --hardware-testing
-      --host ${SSH_JUMP_HOST_IP}:${SSH_JUMP_HOST_PORT} mender-image-tests -k 'not test_network_based_image_update and not test_image_update_broken_kernel'"
+      --host ${SSH_JUMP_HOST_IP}:${SSH_JUMP_HOST_PORT} mender-image-tests
+      -k 'not test_network_based_image_update and not test_image_update_broken_kernel'
       -n 1


### PR DESCRIPTION
The quotes were meant to group the pytest arguments before we introduced the `--` notation for it. And, when introducing such notation, we forgot to unquote it. See:
* https://github.com/mendersoftware/mender-convert/pull/530/commits/b7cc2e1f10420844ca4c3d3c31c3033cd7dd6cbb