### PR TITLE
chore: Revert "Set default `MENDER_CLIENT_VERSION` to 3.5.2"

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -10,7 +10,7 @@ variables:
     description: |-
       Version of mender-artifact for the builder image - 'master' or a specific version
   MENDER_CLIENT_VERSION:
-    value: "3.5.2"
+    value: "latest"
     description: |-
       Version of mender for the converted image- 'latest', 'master' or a specific version
   MENDER_ADDON_CONNECT_VERSION:

--- a/configs/mender_convert_config
+++ b/configs/mender_convert_config
@@ -125,8 +125,7 @@ MENDER_CLIENT_INSTALL="y"
 # This is used to fetch the correct binaries
 #
 # Valid values are "latest" (default), "master" or a specific version
-# MEN-6948 mender-convert is not yet integrated with latest mender-client 4.0.0
-MENDER_CLIENT_VERSION="3.5.2"
+MENDER_CLIENT_VERSION="latest"
 
 # Install Mender Connect addon
 #


### PR DESCRIPTION
Changelog: Set again the default to latest so that we get security updates for the Mender client.

This reverts commits 8471a22 and 5838ac2.