### PR TITLE
4.2.x: fix: Missing DTB inclusion in armbian-based images

### DIFF
--- a/modules/grub.sh
+++ b/modules/grub.sh
@@ -181,5 +181,11 @@ function grub_install_mender_grub() {
                 break
             fi
         done
+    elif [ -d work/rootfs/boot/dtb ]; then
+        # For armbian, dietpi and similar
+        # Keep the existing dtb directory structure as known by u-boot
+        if [ $(find -L work/rootfs/boot/dtb -name '*.dtb' | wc -l) -gt 0 ]; then
+            run_and_log_cmd "sudo cp -rL work/rootfs/boot/dtb work/boot/dtb"
+        fi
     fi
 }


### PR DESCRIPTION
This fix allows U-Boot to properly load the DTB files when chainloading GRUB via UEFI in armbian-based images. In such images, DTBs are normally located in the symlinked /boot/dtb directory and should retain the original directory structure.

This fixes missing wifi interface and cpu sensors with the Orange Pi Zero 3 DietPi converted image

Changelog: Title
Ticket: None

Signed-off-by: Emanuele Faranda <black.silver@hotmail.it>
(cherry picked from commit 5901eb08289c7fdb3d42e9417fba090b4d70f0d4)
