### PR TITLE
ci: from unavailable public runner to self-hosted

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -384,7 +384,7 @@ test_acceptance_ubuntu_raspberrypi3:
 .template:publish:docker-image:
   stage: publish
   tags:
-    - docker
+    - hetzner-amd-beefy
   image: docker
   services:
     - name: docker:20.10.21-dind


### PR DESCRIPTION
Using self-hosted runner because the docker runner is no longer available

Ticket: SEC-1133
Changelog: None


# External Contributor Checklist

🚨 Please review the [guidelines for contributing](https://github.com/mendersoftware/mender/blob/master/CONTRIBUTING.md) to this repository.

- [x] Make sure that all commits follow the conventional commit [specification](https://www.github.com/mendersoftware/mendertesting/commitlint/grammar.md) for the Mender project.

The majority of our contributions are fixes, which means your commit should have
the form below:

```
fix: <SHORT DESCRIPTION OF FIX>

<OPTIONAL LONGER DESCRIPTION>

Changelog: <USER-FRIENDLY-CHANGE-DESCRIPTION> or <None>
Ticket: <TICKET NUMBER> or <None>
```

- [x] Make sure that all commits are signed with [`git --signoff`](https://git-scm.com/book/en/v2/Git-Tools-Signing-Your-Work). Also note that the signoff author must match the author of the commit.

### Description

Using self-hosted runner because the docker runner is no longer available