### PR TITLE
ci: not using custom mtu with self-hosted

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -389,7 +389,6 @@ test_acceptance_ubuntu_raspberrypi3:
   services:
     - name: docker:20.10.21-dind
       alias: docker
-      command: ["--mtu=1440"] # https://gitlab.com/gitlab-com/gl-infra/production/-/issues/5590
   before_script:
     - docker login -u $DOCKER_HUB_USERNAME -p $DOCKER_HUB_PASSWORD
     - docker load -i image.tar


### PR DESCRIPTION
Not using custom MTU setting when using self-hosted runner. This was a fix for public runners.

Ticket: SEC-1133


# External Contributor Checklist

🚨 Please review the [guidelines for contributing](https://github.com/mendersoftware/mender/blob/master/CONTRIBUTING.md) to this repository.

- [x] Make sure that all commits follow the conventional commit [specification](https://www.github.com/mendersoftware/mendertesting/commitlint/grammar.md) for the Mender project.

The majority of our contributions are fixes, which means your commit should have
the form below:

```
fix: <SHORT DESCRIPTION OF FIX>

<OPTIONAL LONGER DESCRIPTION>

Changelog: <USER-FRIENDLY-CHANGE-DESCRIPTION> or <None>
Ticket: <TICKET NUMBER> or <None>
```

- [x] Make sure that all commits are signed with [`git --signoff`](https://git-scm.com/book/en/v2/Git-Tools-Signing-Your-Work). Also note that the signoff author must match the author of the commit.

### Description

Not using custom MTU setting when using self-hosted runner. This was a fix for public runners.