### PR TITLE
MEN-7325: Fix install of Mender client v4

### DIFF
--- a/mender-convert-modify
+++ b/mender-convert-modify
@@ -246,8 +246,8 @@ if [ "${MENDER_CLIENT_INSTALL}" = "y" ]; then
         *)
             # For 4.x, master and latest(*) install the new packages
             log_info "Installing Mender Auth and Mender Update version ${mender_client_deb_version}"
-            deb_get_and_install_package mender-client mender-auth "${mender_client_deb_version}"
-            deb_get_and_install_package mender-client mender-update "${mender_client_deb_version}"
+            deb_get_and_install_package mender-client4 mender-auth "${mender_client_deb_version}"
+            deb_get_and_install_package mender-client4 mender-update "${mender_client_deb_version}"
             mender_client_deb_name="${DEB_NAME}"
 
             log_info "Installing Mender Flash version ${MENDER_FLASH_VERSION}"


### PR DESCRIPTION
Ticket: MEN-7325
Changelog: Fix installation of Mender client v4 when the user specifies the exact version to use with `MENDER_CLIENT_VERSION=a.b.c`. Using `auto` (default) or `latest` does not trigger this bug.