### PR TITLE
feat: support assets directory for local data

### DIFF
--- a/docker-mender-convert
+++ b/docker-mender-convert
@@ -24,6 +24,7 @@ if [ -z "$IMAGE_NAME" -a -z "$GIT_TAG_OR_BRANCH_NAME" ]; then
 fi
 
 IMAGE_NAME=${IMAGE_NAME:-"mendersoftware/mender-convert${GIT_TAG_OR_BRANCH_NAME:+:$GIT_TAG_OR_BRANCH_NAME}"}
+ASSETS_DIRECTORY=${ASSETS_DIRECTORY:-"$(pwd)/assets"}
 CONFIGS_DIRECTORY=${CONFIGS_DIRECTORY:-"$(pwd)/configs"}
 DEPLOY_DIRECTORY=${DEPLOY_DIRECTORY:-"$(pwd)/deploy"}
 INPUT_DIRECTORY=${INPUT_DIRECTORY:-"$(pwd)/input"}
@@ -42,6 +43,7 @@ echo "using log file at: ${LOGS_DIRECTORY}/${LOG_FILE}"
 set +e
 docker run \
   --rm \
+  -v "$ASSETS_DIRECTORY":/mender-convert/assets \
   -v "$CONFIGS_DIRECTORY":/mender-convert/configs \
   -v "$INPUT_DIRECTORY":/mender-convert/input \
   -v "$LOGS_DIRECTORY":/mender-convert/logs \


### PR DESCRIPTION
Custom mender-convert configurations might require data assets which are not parts of a rootfilesystem overlay structure, such as a modified bootloader.

As an alternative to downloading them as part of the conversion script, the /assets directory can be used to hold and provide such assests. The directory is empty by default in the upstream repositoy and mounted into the docker container invoked by docker-mender-convert.

Changelog: Title
Ticket: None


# External Contributor Checklist

🚨 Please review the [guidelines for contributing](https://github.com/mendersoftware/mender/blob/master/CONTRIBUTING.md) to this repository.

- [ ] Make sure that all commits follow the conventional commit [specification](https://www.github.com/mendersoftware/mendertesting/commitlint/grammar.md) for the Mender project.

The majority of our contributions are fixes, which means your commit should have
the form below:

```
fix: <SHORT DESCRIPTION OF FIX>

<OPTIONAL LONGER DESCRIPTION>

Changelog: <USER-FRIENDLY-CHANGE-DESCRIPTION> or <None>
Ticket: <TICKET NUMBER> or <None>
```

- [ ] Make sure that all commits are signed with [`git --signoff`](https://git-scm.com/book/en/v2/Git-Tools-Signing-Your-Work). Also note that the signoff author must match the author of the commit.

### Description

Please describe your pull request.

Thank you!
