### PR TITLE
fix: Install correct packages for Debian 12 and add a warning

### DIFF
--- a/configs/mender_convert_config
+++ b/configs/mender_convert_config
@@ -204,7 +204,7 @@ MENDER_APT_REPO_URL="${MENDER_STORAGE_URL}/repos/debian"
 
 # Mender APT repo available distributions, do not modify this unless you know
 # what you are doing.
-MENDER_APT_REPO_DISTS="debian/buster debian/bullseye ubuntu/bionic ubuntu/focal ubuntu/jammy"
+MENDER_APT_REPO_DISTS="debian/bookworm debian/bullseye ubuntu/noble ubuntu/jammy ubuntu/focal"
 
 # Mender GitHub organization URL prefix
 MENDER_GITHUB_ORG="https://github.com/mendersoftware"

--- a/modules/deb.sh
+++ b/modules/deb.sh
@@ -190,8 +190,9 @@ function deb_get_and_install_package() {
     local deb_distro=$(probe_debian_distro_name)
     local deb_codename=$(probe_debian_distro_codename)
     if ! [[ "$MENDER_APT_REPO_DISTS" == *"${deb_distro}/${deb_codename}"* ]]; then
+        log_warn "OS Distribution ${deb_distro}/${deb_codename} not supported, defaulting to debian/bullseye"
         deb_distro="debian"
-        deb_codename="buster"
+        deb_codename="bullseye"
     fi
 
     DEB_NAME=""


### PR DESCRIPTION
By the looks of it, this has been unmaintained for a while and although we introduced packages for new distros we were silently installing the Debian Buster ones.

Sort the distros from newer to older, and:

Changelog: Modify the list of available APT distros from where to get Mender software by adding `debian/bookworm` and `ubuntu/noble` and removing `ubuntu/focal`.

Changelog(chore): Fallback to Debian Bullseye packages when target distribution is not supported, printing a user facing warning when doing so.