### PR TITLE
feat: make boot partition mount point configurable

### DIFF
--- a/configs/mender_convert_config
+++ b/configs/mender_convert_config
@@ -230,6 +230,20 @@ MENDER_ENABLE_PARTUUID="n"
 # Partition used as the boot partition.
 MENDER_BOOT_PART=""
 
+# Path to mount the boot partition in the root filesystem
+#
+# In order to access the boot partition from the running system,
+# it needs to be mounted to a defined directory location.
+# By default, this is
+# - /boot/efi: for GRUB-EFI based integrations
+# - /uboot: for all other integrations
+#
+# The value of this variable overrides all defaults.
+# Example:
+#   MENDER_BOOT_PART_MOUNT_LOCATION="/boot/firmware"
+#
+#MENDER_BOOT_PART_MOUNT_LOCATION=""
+
 # Partition used as the first (A) rootfs partition.
 MENDER_ROOTFS_PART_A=""
 

--- a/mender-convert-modify
+++ b/mender-convert-modify
@@ -186,10 +186,14 @@ run_and_log_cmd "echo -n ${VERSION_STRING} | sudo tee work/rootfs/etc/mender/scr
 
 log_info "Installing a custom /etc/fstab (see ${MENDER_CONVERT_LOG_FILE} for more info)"
 
-if [ "${MENDER_GRUB_EFI_INTEGRATION}" == "y" ]; then
-    boot_part_mountpoint="/boot/efi"
+if [ -n "${MENDER_BOOT_PART_MOUNT_LOCATION:-}" ]; then
+    boot_part_mountpoint="${MENDER_BOOT_PART_MOUNT_LOCATION}"
 else
-    boot_part_mountpoint="/uboot"
+    if [ "${MENDER_GRUB_EFI_INTEGRATION}" == "y" ]; then
+        boot_part_mountpoint="/boot/efi"
+    else
+        boot_part_mountpoint="/uboot"
+    fi
 fi
 
 run_and_log_cmd "sudo mkdir -p work/rootfs/${boot_part_mountpoint}"


### PR DESCRIPTION
The MENDER_BOOT_PART_MOUNTPOINT variable can be used to configure the mount point for the boot partition which is written to the fstab. If it is not set, the previous hardcoded defaults of /boot/efi respectively /uboot will be used.

Changelog: Title
Ticket: None


# External Contributor Checklist

🚨 Please review the [guidelines for contributing](https://github.com/mendersoftware/mender/blob/master/CONTRIBUTING.md) to this repository.

- [ ] Make sure that all commits follow the conventional commit [specification](https://www.github.com/mendersoftware/mendertesting/commitlint/grammar.md) for the Mender project.

The majority of our contributions are fixes, which means your commit should have
the form below:

```
fix: <SHORT DESCRIPTION OF FIX>

<OPTIONAL LONGER DESCRIPTION>

Changelog: <USER-FRIENDLY-CHANGE-DESCRIPTION> or <None>
Ticket: <TICKET NUMBER> or <None>
```

- [ ] Make sure that all commits are signed with [`git --signoff`](https://git-scm.com/book/en/v2/Git-Tools-Signing-Your-Work). Also note that the signoff author must match the author of the commit.

### Description

Please describe your pull request.

Thank you!
