### PR TITLE
feat: support Raspberry Pi 5, bookworm 64bit

### DIFF
--- a/configs/raspberrypi5_64_config
+++ b/configs/raspberrypi5_64_config
@@ -1,0 +1,3 @@
+MENDER_DEVICE_TYPE="raspberrypi5"
+
+source configs/raspberrypi_64_config

--- a/configs/raspberrypi5_bookworm_64bit_config
+++ b/configs/raspberrypi5_bookworm_64bit_config
@@ -1,0 +1,2 @@
+source configs/include/raspberrypi_bookworm_config
+source configs/raspberrypi5_64_config


### PR DESCRIPTION
This adds basic support for the Raspberry Pi 5, running Raspberry Pi OS based on Debian "bookworm", 64bit.

Changelog: Title
Ticket: None


# External Contributor Checklist

🚨 Please review the [guidelines for contributing](https://github.com/mendersoftware/mender/blob/master/CONTRIBUTING.md) to this repository.

- [ ] Make sure that all commits follow the conventional commit [specification](https://www.github.com/mendersoftware/mendertesting/commitlint/grammar.md) for the Mender project.

The majority of our contributions are fixes, which means your commit should have
the form below:

```
fix: <SHORT DESCRIPTION OF FIX>

<OPTIONAL LONGER DESCRIPTION>

Changelog: <USER-FRIENDLY-CHANGE-DESCRIPTION> or <None>
Ticket: <TICKET NUMBER> or <None>
```

- [ ] Make sure that all commits are signed with [`git --signoff`](https://git-scm.com/book/en/v2/Git-Tools-Signing-Your-Work). Also note that the signoff author must match the author of the commit.

### Description

Please describe your pull request.

Thank you!
