### PR TITLE
fix comparison issue that breaks platform hooks

### DIFF
--- a/configs/raspberrypi_64_config
+++ b/configs/raspberrypi_64_config
@@ -16,7 +16,7 @@ source configs/include/raspberrypi_common_config
 function platform_modify() {
     check_image_bitsize
 
-    if [ ${RASPBERRYPI_OS_REQUIRED_ID:-0} -ne 0 ] && ! check_image_os_id; then
+    if [ -n "${RASPBERRYPI_OS_REQUIRED_ID:+x}" ] && ! check_image_os_id; then
         echo "This configuration requires an image based on $RASPBERRYPI_OS_REQUIRED_ID."
         exit 1
     fi

--- a/configs/raspberrypi_config
+++ b/configs/raspberrypi_config
@@ -11,7 +11,7 @@ source configs/include/raspberrypi_common_config
 function platform_modify() {
     check_image_bitsize
 
-    if [ ${RASPBERRYPI_OS_REQUIRED_ID:-0} -ne 0 ] && ! check_image_os_id; then
+    if [ -n "${RASPBERRYPI_OS_REQUIRED_ID:+x}" ] && ! check_image_os_id; then
         echo "This configuration requires an image based on $RASPBERRYPI_OS_REQUIRED_ID."
         exit 1
     fi


### PR DESCRIPTION
fix: comparison issue that breaks platform hooks

A type comparison issue in line 19 the platform_modify function on the latest 64 bit changes yields:
```shell
2024-10-31 13:22:38 [INFO] [mender-convert-modify] Running hook: platform_modify
configs/raspberrypi_64_config: line 19: [: debian: integer expression expected
```

have fixed that with a suggestion from @danielskinstad 

Changelog: None
Ticket: None