### PR TITLE
ci: Save disk space + Fix published images prefix

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -379,25 +379,32 @@ test_acceptance_raspberrypi4_bookworm_64bit:
 
 .template:publish:s3:
   stage: publish
+  needs:
+    - job: convert_raspbian_raspberrypi4_bookworm_64bit
+      artifacts: true
+    - job: convert_raspbian_raspberrypi4_bookworm_32bit
+      artifacts: true
+    - job: convert_raspbian_raspberrypi4_bullseye_64bit
+      artifacts: true
+    - job: convert_raspbian_raspberrypi4_bullseye_32bit
+      artifacts: true
   image: debian:buster
   before_script:
     - apt update && apt install -yyq awscli curl
     - eval "$(curl https://raw.githubusercontent.com/mendersoftware/mendertesting/master/mender-ci-common.sh)"
-    # Fetch artifacts from temporary S3 bucket
+    - IMAGE_VERSION=${MENDER_CONVERT_PUBLISH_VERSION:-${CI_COMMIT_REF_NAME}}
+  script:
+    # One by one, fetch artifacts from temporary S3 bucket and publish to production S3 bucket
     - for RASPBERRYPI_CONFIG_NAME in raspberrypi4_bookworm_64bit raspberrypi4_bookworm_32bit raspberrypi4_bullseye_64bit raspberrypi4_bullseye_32bit; do
     -   mender_ci_load_tmp_artifact ${RASPBERRYPI_CONFIG_NAME}.tar.gz
     -   tar xzf ${RASPBERRYPI_CONFIG_NAME}.tar.gz
-    - done
-  script:
-    - IMAGE_VERSION=${MENDER_CONVERT_PUBLISH_VERSION:-${CI_COMMIT_REF_NAME}}
-
-    - for RASPBERRYPI_CONFIG_NAME in raspberrypi4_bookworm_64bit raspberrypi4_bookworm_32bit raspberrypi4_bullseye_64bit raspberrypi4_bullseye_32bit; do
     -   PUBLISH_NAME=${RASPBIAN_NAME_PUBLISH}-${RASPBERRYPI_CONFIG_NAME}-mender-convert-${IMAGE_VERSION}.img.xz
     -   echo "Publishing ${PUBLISH_NAME} version to S3"
     -   aws s3 cp ${RASPBERRYPI_CONFIG_NAME}/${RASPBIAN_NAME_PUBLISH}-${RASPBERRYPI_CONFIG_NAME}-mender.img.xz
           s3://$S3_BUCKET_NAME/${RASPBIAN_NAME_PUBLISH}/arm/${PUBLISH_NAME}
     -   aws s3api put-object-acl --acl public-read --bucket $S3_BUCKET_NAME
           --key ${RASPBIAN_NAME_PUBLISH}/arm/${PUBLISH_NAME}
+    -   rm ${RASPBERRYPI_CONFIG_NAME}/${RASPBIAN_NAME_PUBLISH}-${RASPBERRYPI_CONFIG_NAME}-mender.img.xz
 
     -   PUBLISH_NAME=${RASPBIAN_NAME_PUBLISH}-${RASPBERRYPI_CONFIG_NAME}-mender-convert-${IMAGE_VERSION}.mender
     -   echo "Publishing ${PUBLISH_NAME} version to S3"
@@ -405,6 +412,7 @@ test_acceptance_raspberrypi4_bookworm_64bit:
           s3://$S3_BUCKET_NAME/${RASPBIAN_NAME_PUBLISH}/arm/${PUBLISH_NAME}
     -   aws s3api put-object-acl --acl public-read --bucket $S3_BUCKET_NAME
           --key ${RASPBIAN_NAME_PUBLISH}/arm/${PUBLISH_NAME}
+    -   rm ${RASPBERRYPI_CONFIG_NAME}/${RASPBIAN_NAME_PUBLISH}-${RASPBERRYPI_CONFIG_NAME}-mender.mender
     - done
 
 publish:s3:manual:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -28,6 +28,7 @@ variables:
     description: |-
       Version of mender-configure for the converted image - 'latest', 'master' or a specific version
 
+  ## Important: when updating the upstream image update also RASPBERRY_PI_OS_PREFIX in the publish jobs
   ## Auto-update
   RASPBIAN_URL_BOOKWORM_64: "https://downloads.raspberrypi.com/raspios_lite_arm64/images/raspios_lite_arm64-2024-07-04/2024-07-04-raspios-bookworm-arm64-lite.img.xz"
   RASPBIAN_NAME_BOOKWORM_64: 2024-07-04-raspios-bookworm-arm64-lite
@@ -398,35 +399,35 @@ test_acceptance_raspberrypi4_bookworm_64bit:
     - for RASPBERRYPI_CONFIG_NAME in raspberrypi4_bookworm_64bit raspberrypi4_bookworm_32bit raspberrypi4_bullseye_64bit raspberrypi4_bullseye_32bit; do
     -   mender_ci_load_tmp_artifact ${RASPBERRYPI_CONFIG_NAME}.tar.gz
     -   tar xzf ${RASPBERRYPI_CONFIG_NAME}.tar.gz
-    -   PUBLISH_NAME=${RASPBIAN_NAME_PUBLISH}-${RASPBERRYPI_CONFIG_NAME}-mender-convert-${IMAGE_VERSION}.img.xz
+    -   PUBLISH_NAME=${RASPBERRY_PI_OS_PREFIX}-${RASPBERRYPI_CONFIG_NAME}-mender-convert-${IMAGE_VERSION}.img.xz
     -   echo "Publishing ${PUBLISH_NAME} version to S3"
-    -   aws s3 cp ${RASPBERRYPI_CONFIG_NAME}/${RASPBIAN_NAME_PUBLISH}-${RASPBERRYPI_CONFIG_NAME}-mender.img.xz
-          s3://$S3_BUCKET_NAME/${RASPBIAN_NAME_PUBLISH}/arm/${PUBLISH_NAME}
+    -   aws s3 cp ${RASPBERRYPI_CONFIG_NAME}/${RASPBERRY_PI_OS_PREFIX}-${RASPBERRYPI_CONFIG_NAME}-mender.img.xz
+          s3://$S3_BUCKET_NAME/${RASPBERRY_PI_OS_PREFIX}/arm/${PUBLISH_NAME}
     -   aws s3api put-object-acl --acl public-read --bucket $S3_BUCKET_NAME
-          --key ${RASPBIAN_NAME_PUBLISH}/arm/${PUBLISH_NAME}
-    -   rm ${RASPBERRYPI_CONFIG_NAME}/${RASPBIAN_NAME_PUBLISH}-${RASPBERRYPI_CONFIG_NAME}-mender.img.xz
+          --key ${RASPBERRY_PI_OS_PREFIX}/arm/${PUBLISH_NAME}
+    -   rm ${RASPBERRYPI_CONFIG_NAME}/${RASPBERRY_PI_OS_PREFIX}-${RASPBERRYPI_CONFIG_NAME}-mender.img.xz
 
-    -   PUBLISH_NAME=${RASPBIAN_NAME_PUBLISH}-${RASPBERRYPI_CONFIG_NAME}-mender-convert-${IMAGE_VERSION}.mender
+    -   PUBLISH_NAME=${RASPBERRY_PI_OS_PREFIX}-${RASPBERRYPI_CONFIG_NAME}-mender-convert-${IMAGE_VERSION}.mender
     -   echo "Publishing ${PUBLISH_NAME} version to S3"
-    -   aws s3 cp ${RASPBERRYPI_CONFIG_NAME}/${RASPBIAN_NAME_PUBLISH}-${RASPBERRYPI_CONFIG_NAME}-mender.mender
-          s3://$S3_BUCKET_NAME/${RASPBIAN_NAME_PUBLISH}/arm/${PUBLISH_NAME}
+    -   aws s3 cp ${RASPBERRYPI_CONFIG_NAME}/${RASPBERRY_PI_OS_PREFIX}-${RASPBERRYPI_CONFIG_NAME}-mender.mender
+          s3://$S3_BUCKET_NAME/${RASPBERRY_PI_OS_PREFIX}/arm/${PUBLISH_NAME}
     -   aws s3api put-object-acl --acl public-read --bucket $S3_BUCKET_NAME
-          --key ${RASPBIAN_NAME_PUBLISH}/arm/${PUBLISH_NAME}
-    -   rm ${RASPBERRYPI_CONFIG_NAME}/${RASPBIAN_NAME_PUBLISH}-${RASPBERRYPI_CONFIG_NAME}-mender.mender
+          --key ${RASPBERRY_PI_OS_PREFIX}/arm/${PUBLISH_NAME}
+    -   rm ${RASPBERRYPI_CONFIG_NAME}/${RASPBERRY_PI_OS_PREFIX}-${RASPBERRYPI_CONFIG_NAME}-mender.mender
     - done
 
 publish:s3:manual:
   when: manual
   extends: .template:publish:s3
   variables:
-    RASPBIAN_NAME_PUBLISH: 2024-07-04-raspios-bookworm-arm64-lite
+    RASPBERRY_PI_OS_PREFIX: 2024-07-04-raspios-lite
 
 publish:s3:automatic:
   rules:
     - if: '$PUBLISH_MENDER_CONVERT_AUTOMATIC == "true"'
   extends: .template:publish:s3
   variables:
-    RASPBIAN_NAME_PUBLISH: ${RASPBIAN_NAME_PUBLISH}
+    RASPBERRY_PI_OS_PREFIX: 2024-07-04-raspios-lite
 
 # excludes non multiplatform build job
 build:docker:


### PR DESCRIPTION
* ci: Save disk space by downloading artifacts one by one
Since we doubled the number of images, CI jobs are being terminated due
to lack of disk space. Modify the job to get to 1) get only the relevant
artifacts and 2) one board at a time download, publish, remove.
Issue introduced at 306474e.

* ci: Modify the images names to have a common prefix
The image name used to be prefixed with the upstream image, but we
cannot have that anymore as we will have the distro (bookworm, bullseye)
as a suffix.
Modify by having a simplified custom prefix, but that still gives a good
pointer to the upstream image that was used.