### PR TITLE
feat: create sparse images

### DIFF
--- a/configs/debian-qemux86-64_config
+++ b/configs/debian-qemux86-64_config
@@ -19,3 +19,5 @@ MENDER_DEVICE_TYPE="qemux86-64"
 
 # Nothing to copy
 MENDER_COPY_BOOT_GAP="n"
+
+MENDER_SPARSE_IMAGE="y"

--- a/configs/mender_convert_config
+++ b/configs/mender_convert_config
@@ -194,6 +194,14 @@ MENDER_SNAPSHOT_INSTALL="auto"
 # Valid values are "latest" (default), "master" or a specific version
 MENDER_SNAPSHOT_VERSION="latest"
 
+# Mender sparse image file generation
+#
+# By default, mender-convert writes the entire image. When enabled, mender-convert attempts
+# to avoid allocating empty spaces within the image. This can result in the created image
+# using less space on the storage medium while maintaining the expected size.
+# However, some tools may not handle sparse files correctly.
+MENDER_SPARSE_IMAGE="n"
+
 # File storage, containing binary files, do not modify this unless you know
 # what you are doing.
 MENDER_STORAGE_URL="https://downloads.mender.io"

--- a/configs/ubuntu-qemux86-64_config
+++ b/configs/ubuntu-qemux86-64_config
@@ -19,3 +19,5 @@ MENDER_DEVICE_TYPE="qemux86-64"
 
 # Nothing to copy
 MENDER_COPY_BOOT_GAP="n"
+
+MENDER_SPARSE_IMAGE="y"

--- a/modules/disk.sh
+++ b/modules/disk.sh
@@ -60,7 +60,11 @@ disk_get_part_nums() {
 #  $3 - size (in 512 blocks)
 #  $4 - path to output file
 disk_extract_part() {
-    run_and_log_cmd "dd if=$1 of=$4 skip=${2}b bs=1M count=${3}b status=none iflag=count_bytes,skip_bytes"
+    conv=""
+    if [ "${MENDER_SPARSE_IMAGE}" == "y" ]; then
+        conv="conv=sparse"
+    fi
+    run_and_log_cmd "dd if=$1 of=$4 skip=${2}b bs=1M count=${3}b status=none ${conv} iflag=count_bytes,skip_bytes"
 }
 
 # Convert MiB to number of 512 sectors
@@ -98,7 +102,11 @@ disk_align_sectors() {
 # $2 - destination file
 # $3 - offset in number of 512 sectors
 disk_write_at_offset() {
-    run_and_log_cmd "dd if=${1} of=${2} seek=${3} conv=notrunc status=none"
+    conv="conv=notrunc"
+    if [ "${MENDER_SPARSE_IMAGE}" == "y" ]; then
+        conv="${conv},sparse"
+    fi
+    run_and_log_cmd "dd if=${1} of=${2} seek=${3} bs=512 ${conv} status=none"
 }
 
 # Create file system image from directory content


### PR DESCRIPTION
# External Contributor Checklist

🚨 Please review the [guidelines for contributing](https://github.com/mendersoftware/mender/blob/master/CONTRIBUTING.md) to this repository.

- [x] Make sure that all commits follow the conventional commit [specification](https://www.github.com/mendersoftware/mendertesting/commitlint/grammar.md) for the Mender project.

- [x] Make sure that all commits are signed with [`git --signoff`](https://git-scm.com/book/en/v2/Git-Tools-Signing-Your-Work). Also note that the signoff author must match the author of the commit.

### Description

Instead of allocating the whole image on the disk, only allocate the parts that actually contain data. This reduces the required disk space to store or create images. The image does appear to have the normal size but if inspected with `du` or `ls -lsh` the difference becomes apparent.


Example with the image i build:
```
$ ls -lsh
total 244G
234G -rw-r--r-- 1 root root 235G Nov 20 17:30 image-x86_64-mender_old.img
 11G -rw-r--r-- 2 root root 235G Nov 20 17:54 image-x86_64-mender_sparse.img
```

This is done by the `conv=sparse` flag of dd. Alternatively a file can made sparse with `fallocate -d <file>`. But this may only collapse a file, not reduce its footprint while it is created. This may also improve read and write performance of those files in the empty areas, but i did not observe a big speed-up during the image creation.