### PR TITLE
fix: Expand the data partition into the empty space on boot

### DIFF
--- a/configs/images/raspberrypi_raspbian_config
+++ b/configs/images/raspberrypi_raspbian_config
@@ -17,40 +17,6 @@ MENDER_COMPRESS_DISK_IMAGE=lzma
 MENDER_CLIENT_INSTALL="n"
 
 #
-# Resize the data partition to fill the remaining space, using parted, with systemd
-#
-function grow_data_partition() {
-    log_info "Adding systemd init script to run parted and resize the data partition on boot"
-    log_info "to fill all the available space on the storage media"
-    run_and_log_cmd "sudo mkdir -p work/rpi/etc/systemd/system/"
-    run_and_log_cmd "sudo mkdir -p work/rootfs/etc/systemd/system/data.mount.wants/"
-    cat <<- EOF > work/rpi/etc/systemd/system/mender-grow-data.service
-  [Unit]
-  Description=Mender service to grow data partition size
-  DefaultDependencies=no
-  Before=data.mount
-  Before=systemd-growfs@data.service
-
-  [Service]
-  Type=oneshot
-  User=root
-  Group=root
-  ExecStart=/sbin/parted --script /dev/mmcblk0 resizepart ${MENDER_DATA_PART_NUMBER} 100%
-
-  [Install]
-  WantedBy=data.mount
-EOF
-
-    # Install
-    run_and_log_cmd "cp work/rpi/etc/systemd/system/mender-grow-data.service \
-                      work/rootfs/etc/systemd/system/"
-    run_and_log_cmd "ln -sf work/rootfs/etc/systemd/system/mender-grow-data.service \
-                          work/rootfs/etc/systemd/system/data.mount.wants/"
-}
-
-PLATFORM_MODIFY_HOOKS+=(grow_data_partition)
-
-#
 # Allow APT Suite change in the release info
 #
 # Upstream repository http://raspbian.raspberrypi.org/raspbian has changed buster

--- a/configs/mender_convert_config
+++ b/configs/mender_convert_config
@@ -314,6 +314,7 @@ MENDER_CLIENT_DATA_DIR_SERVICE_URL="https://raw.githubusercontent.com/mendersoft
 meta-mender/ab9c1e65abf73cde1065e2a4c2005cfe61ee6e3d/meta-mender-core/recipes-mender/mender-client/files/mender-data-dir.service"
 
 source configs/mender_grub_config
+source configs/systemd_common_config
 
 # Function to create Mender Artifact
 #

--- a/configs/systemd_common_config
+++ b/configs/systemd_common_config
@@ -1,0 +1,32 @@
+#
+# Resize the data partition to fill the remaining space, using parted, with systemd
+#
+function grow_data_partition() {
+    log_info "Adding systemd init script to run parted and resize the data partition on boot"
+    log_info "to fill all the available space on the storage media"
+    run_and_log_cmd "sudo mkdir -p work/rootfs/etc/systemd/system/data.mount.wants/"
+    cat <<- EOF > work/rootfs/etc/systemd/system/mender-grow-data.service
+		  [Unit]
+		  Description=Mender service to grow data partition size
+		  DefaultDependencies=no
+		  Before=data.mount
+		  Before=systemd-growfs@data.service
+
+		  [Service]
+		  Type=oneshot
+		  User=root
+		  Group=root
+		  ExecStart=/sbin/parted --script $(disk_get_device_base "${MENDER_STORAGE_DEVICE_BASE}") resizepart ${MENDER_DATA_PART_NUMBER} 100%
+
+		  [Install]
+		  WantedBy=data.mount
+	EOF
+
+    # Install
+    run_and_log_cmd "ln -sf /etc/systemd/system/mender-grow-data.service \
+                          work/rootfs/etc/systemd/system/data.mount.wants/"
+}
+
+if [ "${MENDER_DATA_PART_GROWFS}" == "y" ]; then
+    PLATFORM_MODIFY_HOOKS+=(grow_data_partition)
+fi


### PR DESCRIPTION
Make sure that the data partition is expanded into the remaining space on boot for all systems.

Ticket: MEN-8191
Changelog: Title

