### PR TITLE
Fix: mender grow fs service

### DIFF
--- a/configs/mender_convert_config
+++ b/configs/mender_convert_config
@@ -55,6 +55,7 @@ MENDER_DATA_PART_MKFS_OPTS=""
 #
 # This feature is utilizing x−systemd.growfs and will only work on systemd 242
 # and newer and nothing will be done if an older systemd version is used.
+# It also uses the parted command which need to be installed on the golden image.
 MENDER_DATA_PART_GROWFS=y
 
 # The name of the image or update that will be built. This is what the device

--- a/configs/systemd_common_config
+++ b/configs/systemd_common_config
@@ -16,7 +16,7 @@ function grow_data_partition() {
 		  Type=oneshot
 		  User=root
 		  Group=root
-		  ExecStart=/sbin/parted --script $(disk_get_device_base "${MENDER_STORAGE_DEVICE_BASE}") resizepart ${MENDER_DATA_PART_NUMBER} 100%
+		  ExecStart=/sbin/parted ${MENDER_STORAGE_DEVICE_BASE} --script  resizepart ${MENDER_DATA_PART_NUMBER} 100%
 
 		  [Install]
 		  WantedBy=data.mount

--- a/modules/disk.sh
+++ b/modules/disk.sh
@@ -336,7 +336,7 @@ disk_get_device_part_number() {
     fi
 }
 
-# Get device base path without partition number from argument.
+# Get device base path without partition number from argument with a partition number.
 # Unrecognized or unsupported device paths will generate an error
 #
 # $1 - device path


### PR DESCRIPTION
Changelog: Title

Mender grow fs service not failure 
Service got blank device to work on with parted.
Just need MENDER_STORAGE_DEVICE_BASE not disk_get_device_base

Ticket:  None


