### PR TITLE
test: Change owner and permissions of ssh keys after copy

### DIFF
--- a/scripts/test/run-tests.sh
+++ b/scripts/test/run-tests.sh
@@ -101,8 +101,6 @@ if [ "$TEST_ALL" == "1" -o "$TEST_PLATFORM" == "ubuntu-qemux86-64" ]; then
   # speed up the process
   wget --progress=dot:giga -N ${UBUNTU_IMAGE_URL} -P input/image/
   UBUNTU_IMAGE_COMPRESSED="${UBUNTU_IMAGE_URL##*/}"
-  mkdir -p input/tests
-  sudo cp -r "tests/ssh-public-key-overlay" "input/tests/"
   convert_and_test "qemux86-64" \
                    "release-1" \
                    "input/image/${UBUNTU_IMAGE_COMPRESSED}" \
@@ -133,8 +131,6 @@ if [ "$TEST_ALL" == "1" -o "$TEST_PLATFORM" == "ubuntu-qemux86-64-no-grub-d" ]; 
   UBUNTU_IMAGE_COMPRESSED="${UBUNTU_IMAGE_URL##*/}"
   UBUNTU_IMAGE_UNCOMPRESSED=${UBUNTU_IMAGE_COMPRESSED%.gz}
   gunzip --force "input/image/${UBUNTU_IMAGE_COMPRESSED}"
-  mkdir -p input/tests
-  sudo cp -r "tests/ssh-public-key-overlay" "input/tests/"
   QEMU_NO_SECURE_BOOT=1 \
                    convert_and_test \
                    "qemux86-64" \
@@ -182,8 +178,6 @@ if [ "$TEST_ALL" == "1" -o "$TEST_PLATFORM" == "debian-qemux86-64" ]; then
   DEBIAN_IMAGE_COMPRESSED="${DEBIAN_IMAGE_URL##*/}"
   DEBIAN_IMAGE_UNCOMPRESSED=${DEBIAN_IMAGE_COMPRESSED%.gz}
   gunzip --force "input/image/${DEBIAN_IMAGE_COMPRESSED}"
-  mkdir -p input/tests
-  sudo cp -r "tests/ssh-public-key-overlay" "input/tests/"
   convert_and_test "qemux86-64" \
                    "release-1" \
                    "input/image/${DEBIAN_IMAGE_UNCOMPRESSED}" \

--- a/scripts/test/test-utils.sh
+++ b/scripts/test/test-utils.sh
@@ -175,19 +175,24 @@ get_pytest_files() {
 }
 
 prepare_ssh_keys() {
-  if [ "$(stat -c %U tests/ssh-public-key-overlay/root)" != "root" ]; then
-    sudo chown -R root:root tests/ssh-public-key-overlay/root
+  # Prepare an overlay with the public key
+  mkdir --parents input/tests
+  sudo cp --recursive "tests/ssh-public-key-overlay" "input/tests/"
+  if [ "$(sudo stat -c %U input/tests/ssh-public-key-overlay/root)" != "root" ]; then
+    sudo chown -R root:root input/tests/ssh-public-key-overlay/root
   fi
-  if [ "$(stat -c %a tests/ssh-public-key-overlay/root)" != "755" ]; then
-    sudo chmod 755 tests/ssh-public-key-overlay/root
+  if [ "$(sudo stat -c %a input/tests/ssh-public-key-overlay/root)" != "755" ]; then
+    sudo chmod 755 input/tests/ssh-public-key-overlay/root
   fi
-  if [ "$(stat -c %a tests/ssh-public-key-overlay/root/.ssh)" != "755" ]; then
-    sudo chmod 700 tests/ssh-public-key-overlay/root/.ssh
+  if [ "$(sudo stat -c %a input/tests/ssh-public-key-overlay/root/.ssh)" != "755" ]; then
+    sudo chmod 700 input/tests/ssh-public-key-overlay/root/.ssh
   fi
-  if [ "$(stat -c %a tests/ssh-public-key-overlay/root/.ssh/authorized_keys)" != "755" ]; then
-    sudo chmod 600 tests/ssh-public-key-overlay/root/.ssh/authorized_keys
+  if [ "$(sudo stat -c %a input/tests/ssh-public-key-overlay/root/.ssh/authorized_keys)" != "755" ]; then
+    sudo chmod 600 input/tests/ssh-public-key-overlay/root/.ssh/authorized_keys
   fi
+
+  # Set also permissions for private key
   if [ "$(stat -c %a tests/ssh-priv-key/key)" != "600" ]; then
-    sudo chmod 600 tests/ssh-priv-key/key
+    chmod 600 tests/ssh-priv-key/key
   fi
 }


### PR DESCRIPTION
Modifying directly the Git checked out files had the annoying inconvenience that block any local operations with Git after running the tests.