### PR TITLE
feat: use the `device-components` repository

### DIFF
--- a/configs/mender_convert_config
+++ b/configs/mender_convert_config
@@ -207,7 +207,7 @@ MENDER_STORAGE_URL="https://downloads.mender.io"
 
 # Mender APT repo url, containing binary files, do not modify this unless you know
 # what you are doing.
-MENDER_APT_REPO_URL="${MENDER_STORAGE_URL}/repos/debian"
+MENDER_APT_REPO_URL="${MENDER_STORAGE_URL}/repos/device-components"
 
 # Mender APT repo available distributions, do not modify this unless you know
 # what you are doing.


### PR DESCRIPTION
Ticket: None
Changelog: Use the new `device-components` repository for packages.
All new device components are published to this repository in favor of
the old `debian` repository.