### PR TITLE
 chore: Use the new package repositories

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -218,7 +218,7 @@ convert_raspbian_raspberrypi3_bookworm_64bit:
     # Set mender-image-tests submodule to correct version
     - git submodule update --init --recursive
     # Get mender-artifact for the tests
-    - wget "https://downloads.mender.io/repos/debian/pool/main/m/mender-artifact/mender-artifact_${MENDER_ARTIFACT_VERSION}-1%2Bubuntu%2B${ACC_TESTS_UBUNTU_DISTRO}_amd64.deb"
+    - wget "https://downloads.mender.io/repos/workstation-tools/pool/main/m/mender-artifact/mender-artifact_${MENDER_ARTIFACT_VERSION}-1%2Bubuntu%2B${ACC_TESTS_UBUNTU_DISTRO}_amd64.deb"
     - dpkg --install mender-artifact_${MENDER_ARTIFACT_VERSION}-1+ubuntu+${ACC_TESTS_UBUNTU_DISTRO}_amd64.deb
     - rm mender-artifact_${MENDER_ARTIFACT_VERSION}-1+ubuntu+${ACC_TESTS_UBUNTU_DISTRO}_amd64.deb
     # Prepare versions file for mender-convert

--- a/Dockerfile
+++ b/Dockerfile
@@ -71,8 +71,8 @@ RUN echo "Defaults        secure_path=\"/usr/local/sbin:/usr/local/bin:/usr/sbin
 RUN chmod 0440 /etc/sudoers.d/secure_path_override
 
 RUN deb_filename=mender-artifact_${MENDER_ARTIFACT_VERSION}-1%2Bubuntu%2Bnoble_${TARGETARCH}.deb && \
-    wget "https://downloads.mender.io/repos/debian/pool/main/m/mender-artifact/${deb_filename}" \
-    --output-document=/mender-artifact.deb && apt install /mender-artifact.deb && rm /mender-artifact.deb
+    wget "https://downloads.mender.io/repos/workstation-tools/pool/main/m/mender-artifact/${deb_filename}" \
+    --output-document=/mender-artifact.deb && apt -y --fix-broken install /mender-artifact.deb && rm /mender-artifact.deb
 
 WORKDIR /
 


### PR DESCRIPTION
Old debian packages repository has been migrated
into two separated package repositories:
* workstation-tool
* device-components

From now on packages should be installed from the
new repositories.

Ticket: QA-1090
Changelog: Use the new package repositories

Signed-off-by: Paweł Poławski <pawel.polawski@northern.tech>