### PR TITLE
systemd_common_config: add --fix option to parted call

### DIFF
--- a/configs/systemd_common_config
+++ b/configs/systemd_common_config
@@ -16,7 +16,7 @@ function grow_data_partition() {
 		  Type=oneshot
 		  User=root
 		  Group=root
-		  ExecStart=/sbin/parted --script $(disk_get_device_base "${MENDER_STORAGE_DEVICE_BASE}") resizepart ${MENDER_DATA_PART_NUMBER} 100%
+		  ExecStart=/sbin/parted --fix --script $(disk_get_device_base "${MENDER_STORAGE_DEVICE_BASE}") resizepart ${MENDER_DATA_PART_NUMBER} 100%
 
 		  [Install]
 		  WantedBy=data.mount


### PR DESCRIPTION
# External Contributor Checklist

🚨 Please review the [guidelines for contributing](https://github.com/mendersoftware/mender/blob/master/CONTRIBUTING.md) to this repository.

- [x] Make sure that all commits follow the conventional commit [specification](https://github.com/mendersoftware/mendertesting/blob/master/commitlint/grammar.md) for the Mender project.

The majority of our contributions are fixes, which means your commit should have
the form below:

```
fix: <SHORT DESCRIPTION OF FIX>

<OPTIONAL LONGER DESCRIPTION>

Changelog: <USER-FRIENDLY-CHANGE-DESCRIPTION> or <None>
Ticket: <TICKET NUMBER> or <None>
```

- [x] Make sure that all commits are signed with [`git --signoff`](https://git-scm.com/book/en/v2/Git-Tools-Signing-Your-Work). Also note that the signoff author must match the author of the commit.

### Description

If the GPT header does not include the full disk size (can happen to generate smaller images), parted is going to fail because of an exception.

Add the --fix option to fix those exceptions and allow parted to resize the data partition.
