### PR TITLE
MEN-8783: fix backup and restore of CA certificates

### DIFF
--- a/modules/chroot.sh
+++ b/modules/chroot.sh
@@ -24,7 +24,7 @@ function chroot_setup() {
     # Keep a copy of the resolv.conf, and copy in our own, we will need it during chroot
     # execution. We need to check for link specifically, because we want to treat a broken symlink
     # (which it often will be) as existing, but the normal check treats it as non-existing.
-    if [ -e "$directory/etc/resolv.conf" -o -h "$directory/etc/resolv.conf" ]; then
+    if [ -e "$directory/etc/resolv.conf" ]; then
         mv "$directory/etc/resolv.conf" "$directory/etc/resolv.conf.orig"
     fi
     cp /etc/resolv.conf "$directory/etc/resolv.conf"
@@ -105,7 +105,7 @@ function chroot_teardown() {
     fi
 
     rm -f "$directory/etc/resolv.conf"
-    if [ -e "$directory/etc/resolv.conf.orig" -o -h "$directory/etc/resolv.conf.orig" ]; then
+    if [ -e "$directory/etc/resolv.conf.orig" ]; then
         mv "$directory/etc/resolv.conf.orig" "$directory/etc/resolv.conf"
     fi
 


### PR DESCRIPTION
(Commit marked as chore and not fix because the bug is not released).

Bug introduced at:
* https://github.com/mendersoftware/mender-convert/commit/1f590014d7828dc43b3a975fe7a6aa56ca25ee15

The previous implementation had the flaw that `rm ... ca-certificates*` would remove the .orig directory before it could be restored. Also it was treating differently the certs in /etc/ssl which were backup one by one and the ones from /etc/ca-certificates which would be copy at the directory level.

The new code has explicit handling of the conf first and then explicit handling of the directories, which makes it more robust.