### PR TITLE
QA-1167: Automatically publish images on Git tags

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -397,6 +397,10 @@ publish:s3:manual:
 publish:s3:automatic:
   rules:
     - if: '$PUBLISH_MENDER_CONVERT_AUTOMATIC == "true"'
+    # Publish automatically on Git tags
+    # This may happen before we manually test the images, but as long as we
+    # don't update the Mender Docs they are to be treated as release candidates.
+    - if: '$CI_COMMIT_TAG =~ /^v?\d+\.\d+\.\d+$/'
   extends: .template:publish:s3
   variables:
     RASPBERRY_PI_OS_PREFIX: 2024-10-22-raspios-lite


### PR DESCRIPTION
This is part of the effort to release `mender-convert` as an independent component from the rest of the ecosystem. Previously the publish of the images was triggered from `mender-qa` and couple to Mender Client release. We are now de-coupling them at:
* https://github.com/mendersoftware/mender-qa/pull/812