### PR TITLE
RPi5 should use kernel_2712.img (not kernel8.img)

### DIFF
--- a/configs/raspberrypi/uboot/include/raspberrypi5_64_config
+++ b/configs/raspberrypi/uboot/include/raspberrypi5_64_config
@@ -1,5 +1,6 @@
 MENDER_DEVICE_TYPE="raspberrypi5_64"
 
+RASPBERRYPI_KERNEL_IMAGE="kernel_2712.img" # RPi5 could run kernel8.img, but kernel_2712.img is optimized for RPi5
 source configs/raspberrypi/uboot/include/raspberrypi_64_config
 
 # Override the U-Boot binary set in raspberrypi_64_config. The binary

--- a/configs/raspberrypi/uboot/include/raspberrypi_64_config
+++ b/configs/raspberrypi/uboot/include/raspberrypi_64_config
@@ -1,8 +1,8 @@
 # Binaries generated with the following script:
 #    https://github.com/mendersoftware/mender-convert-integration-scripts/blob/master/build-uboot-rpi64.sh
 
-# in the Aarch64 case, it seems to always be "kernel8.img"
-RASPBERRYPI_KERNEL_IMAGE="kernel8.img"
+# in the Aarch64 case, it is "kernel8.img" for RPi4, but RPi5 can override this to use "kernel_2712.img" (for RPi5-specific optimizations) -- see raspberrypi5_64_config
+RASPBERRYPI_KERNEL_IMAGE="${RASPBERRYPI_KERNEL_IMAGE:-kernel8.img}"
 
 RASPBERRYPI_BINARIES="raspberrypi_arm64-2024.04.tar.gz"
 RASPBERRYPI_BINARIES_URL="${MENDER_STORAGE_URL}/mender-convert/uboot/raspberrypi64/${RASPBERRYPI_BINARIES}"


### PR DESCRIPTION
The following (`kernel8.img`) works for RPi5, but is not optimal:

https://github.com/mendersoftware/mender-convert/blob/5.1.0/configs/raspberrypi/uboot/include/raspberrypi_64_config#L4-L5

Ref: https://www.raspberrypi.com/documentation/computers/config_txt.html#kernel  
_"The Raspberry Pi 5, 500, 500+, and Compute Module 5 firmware defaults to loading `kernel_2712.img` because this image contains optimisations specific to those models (e.g. 16K page-size). If this file is not present, then the common 64-bit kernel (`kernel8.img`) will be loaded instead."_

It's better if RPi5 uses `kernel_2712.img`, since it has optimizations.

