### PR TITLE
chore: Update mender-artifact arguments to match latest version

### DIFF
--- a/configs/mender_convert_config
+++ b/configs/mender_convert_config
@@ -363,7 +363,7 @@ mender_create_artifact() {
     local -r device_types="${1}"
     local -r artifact_name="${2}"
     local -r image_name="${3}"
-    local -r all_device_types="$(for device_type in $device_types; do echo " --device-type $device_type"; done)"
+    local -r all_device_types="$(for device_type in $device_types; do echo " --compatible-types $device_type"; done)"
 
     mender_artifact=deploy/${image_name}.mender
     log_info "Writing Mender artifact to: ${mender_artifact}"

--- a/mender-convert-package
+++ b/mender-convert-package
@@ -234,7 +234,7 @@ rootfs_img_checksum=$(sha256sum work/rootfs.img | cut -d ' ' -f1)
 run_and_log_cmd "mender-artifact write bootstrap-artifact \
                     --artifact-name "${MENDER_ARTIFACT_NAME}" \
                     --no-progress \
-                    --device-type  "${device_type}" \
+                    --compatible-types "${device_type}" \
                     --provides rootfs-image.version:"${MENDER_ARTIFACT_NAME}" \
                     --provides rootfs-image.checksum:${rootfs_img_checksum} \
                     --clears-provides 'rootfs-image.*' \


### PR DESCRIPTION
In the latest version of mender-artifact parameter `--device-type` has been replaced with `--compatible-types`. This requires update all mender-artifact calls which still use old version of argument name.

Ticket: MEN-9344
