### PR TITLE
modules/disk.sh: support Technologic Systems /dev/tssdcard paths

### DIFF
--- a/modules/disk.sh
+++ b/modules/disk.sh
@@ -313,6 +313,9 @@ disk_get_device_part_number() {
         /dev/mmcblk*p*)
             dev_part=$(echo $1 | cut -dp -f2)
             ;;
+        /dev/tssdcard[a-z][0-9]*)
+            dev_part=${1##*[!0-9]}
+            ;;
         /dev/[sh]d[a-z][1-9]*)
             dev_part=${1##*d[a-z]}
             ;;
@@ -348,6 +351,12 @@ disk_get_device_base() {
             ;;
         /dev/mmcblk*p*)
             dev_base=$(echo $1 | cut -dp -f1)
+            ;;
+        /dev/tssdcard[a-z][0-9]*)
+            dev_base=${1%%[0-9]*}
+            ;;
+        /dev/tssdcard[a-z])
+            dev_base=$1
             ;;
         /dev/[sh]d[a-z]*)
             dev_base=${1%%[1-9]*}


### PR DESCRIPTION
feat: modules/disk.sh: support Technologic Systems /dev/tssdcard paths

Some Technologic Systems boards, specifically in my case the TS-7800-V2, expose SD cards as /dev/tssdcard[a-z]. Proposing this PR to prevent having to keep a locally modified copy of disk.sh up to date for myself or anyone else using Mender with this hardware.

Ticket: None

Signed-off-by: Dominic A. Ottaviano II <dottaviano@thinkipa.com>