### PR TITLE
chore: remove unused publish job

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -472,6 +472,11 @@ publish:image:saas:
   rules:
     - when: never
 
+# excludes unused job
+publish:image-multiplatform:mender:
+  rules:
+    - when: never
+
 ####################
 # Hardware testing #
 ####################


### PR DESCRIPTION
The job uses the legacy release tool to check if it's part of a release, and if not it exits the job with allow_failure. Since mender-convert will never be part of another legacy release, the job will always fail. Furthermore, the container image is published by the `publish:image-multiplatform` job, so the removed job would be redundant even if it passed.