### PR TITLE
feat: support zstd compression

### DIFF
--- a/configs/mender_convert_config
+++ b/configs/mender_convert_config
@@ -14,6 +14,7 @@
 # 'none' - No compression
 # 'gzip' - Compress with gzip
 # 'lzma' - Compress with xz (LZMA)
+# 'zstd' - Compress with zstd
 MENDER_COMPRESS_DISK_IMAGE=gzip
 
 # Compression algorithm for Mender Artifact

--- a/mender-convert-package
+++ b/mender-convert-package
@@ -381,6 +381,10 @@ case "${MENDER_COMPRESS_DISK_IMAGE}" in
         log_info "Compressing ${img_path}.xz"
         run_and_log_cmd "pxz --best --force ${img_path}"
         ;;
+    zstd)
+        log_info "Compressing ${img_path}.zst"
+        run_and_log_cmd "zstd -10 -zfT0 --no-progress --rm ${img_path}"
+        ;;
     none)
         :
         ;;

--- a/modules/decompressinput.sh
+++ b/modules/decompressinput.sh
@@ -39,6 +39,9 @@ function compression_type()  {
         *.xz)
             echo "lzma"
             ;;
+        *.zst)
+            echo "zstd"
+            ;;
         *)
             log_fatal "Unsupported compression type: ${disk_image}. Please uncompress the image yourself."
             ;;
@@ -79,8 +82,13 @@ function decompress_image()  {
             disk_image=${disk_image%.xz}
             xzcat "${input_image}" > "${disk_image}"
             ;;
+        zstd)
+            log_info "Decompressing ${disk_image}..."
+            disk_image=${disk_image%.zst}
+            zstdcat "${input_image}" > "${disk_image}"
+            ;;
         *)
-            log_fatal "Unsupported input image format: ${input_image}. We support: '.img', '.gz', '.zip', '.xz'."
+            log_fatal "Unsupported input image format: ${input_image}. We support: '.img', '.gz', '.zip', '.xz', '.zst'."
             ;;
     esac
     echo "${disk_image}"


### PR DESCRIPTION
Some of our tooling only has the option to use gzip or zstd. As zstd is a bit faster this has the preference. Bmaptool also supports zstd so it seemed obvious to add this to mender-convert as well.
