### PR TITLE
feat: rootfs b filesystem inclusion can be switched off

### DIFF
--- a/configs/mender_convert_config
+++ b/configs/mender_convert_config
@@ -244,6 +244,9 @@ MENDER_STORAGE_DEVICE_BASE=/dev/mmcblk0p
 # Partition number of boot partition
 MENDER_BOOT_PART_NUMBER="1"
 
+# Include root filesystem B in the image
+MENDER_ROOTFS_PART_B_INCLUDE="y"
+
 # Partition number of root filesystem A
 MENDER_ROOTFS_PART_A_NUMBER="2"
 

--- a/mender-convert-package
+++ b/mender-convert-package
@@ -347,8 +347,10 @@ log_info "Writing boot partition image"
 disk_write_at_offset "${boot_part}" "${img_path}" "${boot_part_start}"
 log_info "Writing rootfsa partition image"
 disk_write_at_offset "${output_dir}/rootfs.img" "${img_path}" "${rootfsa_start}"
-log_info "Writing rootfsb partition image"
-disk_write_at_offset "${output_dir}/rootfs.img" "${img_path}" "${rootfsb_start}"
+if [ "${MENDER_ROOTFS_PART_B_INCLUDE}" == "y" ]; then
+    log_info "Writing rootfsb partition image"
+    disk_write_at_offset "${output_dir}/rootfs.img" "${img_path}" "${rootfsb_start}"
+fi
 log_info "Writing data partition image"
 disk_write_at_offset "${output_dir}/data.img" "${img_path}" "${data_start}"
 


### PR DESCRIPTION
Added MENDER_ROOTFS_PART_B_INCLUDE variable to decide if the the rootfs image should get written to the B partition. This can be used to decrease the size of the initial deployment image to speed up flashing. The variable defaults to "y" so that the default behaviour of mender-convert does not change.

ticket: None