### PR TITLE
feat: Recognize systemd-repart schema

### DIFF
--- a/mender-convert-modify
+++ b/mender-convert-modify
@@ -91,6 +91,9 @@ source modules/config.sh $(printf "%q " "${configs[@]}")
 boot_part=$(disk_boot_part)
 root_part=$(disk_root_part)
 
+log_info "Boot partition set to: ${boot_part}"
+log_info "Root partition set to: ${root_part}"
+
 # Sysfs device paths
 boot_part_device=$(disk_boot_part_device)
 data_part_device=$(disk_data_part_device)

--- a/modules/disk.sh
+++ b/modules/disk.sh
@@ -190,8 +190,28 @@ disk_boot_part() {
     # We also need to adjust the part number of the rootfs part depending on if
     # boot part was extracted or generated.
     boot_part="work/boot-generated.vfat"
+    # Let me add a little more dance here with the "modern" paritioning schema.
+    # In short this madness is called systemd-repart convention and it has two
+    # pools: 1-11 for "stable" partitions like root and 12-15 for "special"
+    # partitions like boot, EFI etc.
+    # In the classic schema there is:
+    # * part-1.fs representing EFI
+    # * part-2.fs representing rootfs
+    # In the modern schema the numbering is different:
+    # * part-1.fs representing rootfs
+    # * part-14.fs representing BIOS
+    # * part-15.fs representing EFI
+    # Idea behind above enumerating schema is to always keep rootfs and core
+    # partitions assigned to numbers from range 1 - 11. This way any changes
+    # to special partitions shall not break the hardcoded references to rootfs
+    # (like assumption that root will always be /dev/mmcblk0p1)
     if [ ! -f ${boot_part} ]; then
-        boot_part="work/part-1.fs"
+        # Detect systemd-repart schema
+        if [ -f "work/part-15.fs" ]; then
+            boot_part="work/part-15.fs"
+        else
+            boot_part="work/part-1.fs"
+        fi
     fi
     echo "${boot_part}"
 }
@@ -201,7 +221,12 @@ disk_boot_part() {
 disk_root_part() {
     boot_part="work/boot-generated.vfat"
     if [ ! -f ${boot_part} ]; then
-        root_part="work/part-2.fs"
+        # Detect systemd-repart schema
+        if [ -f "work/part-15.fs" ]; then
+            root_part="work/part-1.fs"
+        else
+            root_part="work/part-2.fs"
+        fi
     else
         root_part="work/part-1.fs"
     fi


### PR DESCRIPTION
In old images we use to recognize only standard partitioning:
* partition 1 - EFI
* parittion 2 - rootfs

systemd-repart schema creates two pools - one for "static" partitions like rootfs to not break the references (numbers 1-11), and one for "special" partitions which may change / shift in future, like EFI (numbers 12-15).

Images compatible with systemd-repart schema will have:
* partition 1 - rootfs
* partition 14 - boot
* partition 15 - EFI


