### PR TITLE
feat: configurable data filesystem size

### DIFF
--- a/configs/mender_convert_config
+++ b/configs/mender_convert_config
@@ -111,6 +111,11 @@ MENDER_BOOT_PART_SIZE_MB="40"
 # on first boot to occupy the renaming free blocks on the physical storage.
 MENDER_DATA_PART_SIZE_MB="128"
 
+# The size of the data filesystems, in MiB. If the value is -1, mender-convert
+# will use the maximum size that will fit inside the created partition.
+#
+MENDER_DATA_FS_SIZE_MB="-1"
+
 # Alignment of partitions used when building partitioned images, expressed in
 # bytes
 #

--- a/mender-convert-package
+++ b/mender-convert-package
@@ -240,8 +240,33 @@ run_and_log_cmd "mender-artifact write bootstrap-artifact \
                     --clears-provides 'rootfs-image.*' \
                     --output-path work/data/mender/bootstrap.mender"
 
+actual_datafs_size=$(sudo du -s --block-size=512 work/data | cut -f 1)
+
+# MiB -> 512 sectors
+image_datafs_size_sectors=$(disk_mb_to_sectors ${MENDER_DATA_FS_SIZE_MB})
+
+if [ "${MENDER_DATA_FS_SIZE_MB}" -eq -1 ]; then
+    datafs_image_sectors="${data_part_sectors}"
+else
+    datafs_image_sectors="${image_datafs_size_sectors}"
+fi
+
+if [ "${datafs_image_sectors}" -lt "${actual_datafs_size}" ]; then
+    log_warn "The configured data filesystem size ${MENDER_DATA_FS_SIZE_MB} MiB is too small."
+    log_warn "The file content size is ${actual_datafs_size} MiB"
+    log_fatal "You can try adjusting MENDER_DATA_FS_SIZE_MB and/or MENDER_DATA_PART_SIZE_MB to increase the filesystem size."
+fi
+
+if [ ${datafs_image_sectors} -gt ${data_part_sectors} ]; then
+    log_warn "The calculated data partition size $(disk_sectors_to_mb ${data_part_sectors}) MiB is too small."
+    log_warn "The actual data image size is $(disk_sectors_to_mb ${datafs_image_sectors}) MiB"
+    log_fatal "You can try adjusting the MENDER_STORAGE_TOTAL_SIZE_MB or MENDER_DATA_PART_SIZE_MB variable to increase available space, or modify MENDER_DATA_PART_FS_SIZE to reduce the size of the data filesystem."
+fi
+
+log_info "Data filesystem size will be $(disk_sectors_to_mb ${datafs_image_sectors}) MiB"
+
 disk_create_file_system_from_folder "work/data/" "work/data.img" \
-    "${data_part_sectors}" "${image_fs_type}"
+    "${datafs_image_sectors}" "${image_fs_type}"
 run_and_log_cmd "rm -rf work/data"
 
 if [ "${MENDER_CLIENT_INSTALL}" != "y" ]; then


### PR DESCRIPTION
### Description

added MENDER_DATA_FS_SIZE_MB variable to configure the filesystem size of the data partition. This can be used to decrease the size of the data partition in the initial deployment image.

Ticket: None

In our workflow we define the data partition size and setup the root partition size to automatically scale to the remaining space. Because of the way mender-convert works this results in the whole data partition being included in the bmap. For now the easiest solution is configuring the filesystem size of the data partition separate from the partition size.

Ideally mender-convert should not use any intermediary images but build everything directly in the final image. However this has its own set of challenges.

Let me know if this is usable as is or if needs any changes.