### PR TITLE
fix: prevent sudo prompt for help and version commands

### DIFF
--- a/mender-convert
+++ b/mender-convert
@@ -78,9 +78,6 @@ function trap_term() {
     echo "Program interrupted by user"
 }
 
-trap trap_term INT TERM
-trap trap_exit EXIT
-
 # We only handle a selection of the arguments here, the rest are passed on
 # to the sub-scripts.
 while (("$#")); do
@@ -112,6 +109,9 @@ if [ -z "${MENDER_ARTIFACT_NAME}" ]; then
     echo -e "\tMENDER_ARTIFACT_NAME=\"release-1\" ./mender-convert"
     exit 1
 fi
+
+trap trap_term INT TERM
+trap trap_exit EXIT
 
 testscfg_init
 


### PR DESCRIPTION
Previously, running `mender-convert --help` or `mender-convert --version` would prompt the user for sudo after it has already printed the output, which is totally unnecessary.

Changelog: Title
Ticket: MEN-10070


# External Contributor Checklist

🚨 Please review the [guidelines for contributing](https://github.com/mendersoftware/mender/blob/master/CONTRIBUTING.md) to this repository.

- [ ] Make sure that all commits follow the conventional commit [specification](https://github.com/mendersoftware/mendertesting/blob/master/commitlint/grammar.md) for the Mender project.

The majority of our contributions are fixes, which means your commit should have
the form below:

```
fix: <SHORT DESCRIPTION OF FIX>

<OPTIONAL LONGER DESCRIPTION>

<OPTIONAL Ticket: <TICKET NUMBER>>
```

- [x] Make sure that all commits are signed with [`git --signoff`](https://git-scm.com/book/en/v2/Git-Tools-Signing-Your-Work). Also note that the signoff author must match the author of the commit.

### Description

Please describe your pull request.

Thank you!
