### PR TITLE
ci: drop the per repo renovate job

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -117,16 +117,12 @@ include:
   - component: gitlab.com/Northern.tech/Mender/mendertesting/release-docs-changelog@master
     inputs:
       remote_changelog_file: "32.mender-convert/docs.md"
-  - component: gitlab.com/Northern.tech/Mender/mendertesting/renovate@master
-    inputs:
-      stage: "renovate"
 
 default:
   tags: !reference [.qa-common-default-runner, tags]
   retry: !reference [.qa-common-default-retry, retry]
 
 stages:
-  - renovate
   - test
   - build
   - convert


### PR DESCRIPTION
Renovate now runs centrally from NorthernTechHQ/renovate-ring, which reads this repo's renovate.json5 straight from GitHub. Nothing about grouping or managers changes.

The job only ever triggered on a pipeline schedule and that schedule is already deleted, so this removes config that can no longer run.